### PR TITLE
Fixed Google Attestation for login

### DIFF
--- a/Pod/Classes/Categories/NSString+SnapchatKit.h
+++ b/Pod/Classes/Categories/NSString+SnapchatKit.h
@@ -32,6 +32,8 @@
 + (NSString *)timestamp;
 + (NSString *)timestampFrom:(NSDate *)date;
 + (NSString *)queryStringWithParams:(NSDictionary *)params;
++ (NSString *)queryStringWithParams:(NSDictionary *)params URLEscapeValues:(BOOL)escapeValues;
+
 @end
 
 

--- a/Pod/Classes/Networking/SKClient.m
+++ b/Pod/Classes/Networking/SKClient.m
@@ -339,11 +339,11 @@ NSString * const kAttestationBase64Request = @"ClMKABIUY29tLnNuYXBjaGF0LmFuZHJva
                                         @"apk_digest": SKAttestation.digest9_14_2};
                 
                 request.URL = [NSURL URLWithString:SKAttestation.protobufPOSTURL];
-                request.HTTPBody = [[NSString queryStringWithParams:query] dataUsingEncoding:NSUTF8StringEncoding];
+                request.HTTPBody = [[NSString queryStringWithParamsForAttestion:query] dataUsingEncoding:NSUTF8StringEncoding];
+                [request setValue:@"application/x-www-form-urlencoded" forHTTPHeaderField:@"Content-Type"];
+                
                 [[session dataTaskWithRequest:request completionHandler:^(NSData *data2, NSURLResponse *response2, NSError *error2) {
-                    /////////////////////////////////
-                    // This is where I get the 400 //
-                    /////////////////////////////////
+                    
                     if (!error2 && [(NSHTTPURLResponse *)response2 statusCode] == 200) {
                         jsonError = nil;
                         json = [NSJSONSerialization JSONObjectWithData:data2 options:0 error:&jsonError];
@@ -355,6 +355,8 @@ NSString * const kAttestationBase64Request = @"ClMKABIUY29tLnNuYXBjaGF0LmFuZHJva
                             request.URL = [NSURL URLWithString:SKAttestation.attestationURL];
                             request.HTTPBody = [json[@"binary"] base64DecodedData];
                             [request setValue:SKAttestation.userAgent forHTTPHeaderField:SKHeaders.userAgent];
+                            [request setValue:SKHeaders.values.protobuf forHTTPHeaderField:SKHeaders.contentType];
+                            
                             [[session dataTaskWithRequest:request completionHandler:^(NSData *data3, NSURLResponse *response3, NSError *error3) {
                                 if (!error3 && [(NSHTTPURLResponse *)response3 statusCode] == 200) {
                                     jsonError = nil;


### PR DESCRIPTION
A few simple changes:
1. Explicitly set Content-Type for all the attestation requests.
2. Created a [new NSString category method](https://github.com/KiranPanesar/SnapchatKit/blob/f5b874c5bf0593afd53153044c7e0fecb9983442/Pod/Classes/Categories/NSString%2BSnapchatKit.h#L35) to using real URL escaping for query parameters.
3. Implemented the new NSString category method to correctly escape parameters sent in for attestation.
