### PR TITLE
Add Mantle to the project

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -6,7 +6,9 @@ xcodeproj 'SnapchatKit-OSX/SnapchatKit-OSX.xcodeproj'
 xcodeproj 'SnapchatKit.xcodeproj'
 
 target 'SnapchatKit_Example', :exclusive => true do
-  # link_with 'SnapchatKit_Example', 'SnapchatKit_Tests'
+  platform :ios, '9.0'
+  link_with 'SnapchatKit_Example'
+
   pod "SnapchatKit", :path => "../"
 end
 

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -8,18 +8,15 @@ xcodeproj 'SnapchatKit.xcodeproj'
 target 'SnapchatKit_Example', :exclusive => true do
   # link_with 'SnapchatKit_Example', 'SnapchatKit_Tests'
   pod "SnapchatKit", :path => "../"
-  pod 'Mantle'
 end
 
 target 'SnapchatKit-OSX', :exclusive => true do
   xcodeproj 'SnapchatKit-OSX/SnapchatKit-OSX.xcodeproj'
   platform :osx, '10.8'
   link_with 'SnapchatKit-OSX'
-  pod "SnapchatKit", :path => "../"
-  pod 'Mantle'
+  pod 'SnapchatKit', :path => '../'
 end
 
 target 'SnapchatKit_Tests', :exclusive => true do
-  pod "SnapchatKit", :path => "../"
-  pod 'Mantle'
+  pod 'SnapchatKit', :path => '../'
 end

--- a/Example/Pods/Local Podspecs/SnapchatKit.podspec.json
+++ b/Example/Pods/Local Podspecs/SnapchatKit.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "SnapchatKit",
-  "version": "0.3.0",
+  "version": "0.3.5",
   "summary": "An Objective-C implementation of the unofficial Snapchat API.",
   "homepage": "https://github.com/ThePantsThief/SnapchatKit",
   "license": "MIT",
@@ -9,7 +9,7 @@
   },
   "source": {
     "git": "https://github.com/ThePantsThief/SnapchatKit.git",
-    "tag": "0.3.0"
+    "tag": "0.3.5"
   },
   "social_media_url": "https://twitter.com/ThePantsThief",
   "requires_arc": true,
@@ -23,5 +23,10 @@
     "Pod/Dependencies/*",
     "Pod/Dependencies/**/*"
   ],
+  "dependencies": {
+    "Mantle": [
+      "~> 2.0"
+    ]
+  },
   "libraries": "z"
 }

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -11,12 +11,14 @@
 		00E35003DE132CA79A526FCE89D77E16 /* RingBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 31F648378E994908BE3DEFFBD2CEB0CB /* RingBuffer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		00F6A1A5886C968EAEF709F025C629BD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46EF97B3320D5567B3CD996D681E6DB9 /* Foundation.framework */; };
 		0120362E8FDC4F1EBE0377D52527161F /* UnknownFieldSet.m in Sources */ = {isa = PBXBuildFile; fileRef = E7FF2C7F1C9F03E9F9FFEEEB71828E5D /* UnknownFieldSet.m */; };
+		016DCC45D6DA2C1272C0E6B1ADE05A1C /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = A7E0035C4D44DD28CDC29DBEE88C9580 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		019F98F946817BFC8036990FC4866029 /* SKSharedStoryDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 783EA1ECC5FDE5F2CB4C6E1B8B5B9896 /* SKSharedStoryDescription.m */; };
 		01F6E48CB9D03467B4E5E15A86E9E696 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46EF97B3320D5567B3CD996D681E6DB9 /* Foundation.framework */; };
 		023388DFA5754C45B0A6A5C0F26D3077 /* Pods-SnapchatKit-OSX-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 1DC3BE7BB86B644F4B88640AA93A535C /* Pods-SnapchatKit-OSX-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		024CB5A94F8C400B1D9BB8FECD524A98 /* crypt.h in Headers */ = {isa = PBXBuildFile; fileRef = 79F59B49CE4DC99DF440AE4D85E72F6C /* crypt.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		02A7B6428992BB41A044CDFCF0F97B46 /* AbstractMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 07EAD9F6F9FA6CF821F00410E5793C55 /* AbstractMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		042DA1E4404BBD3A35D5275D4A29413A /* SKClient+Account.m in Sources */ = {isa = PBXBuildFile; fileRef = 20F34E602ECE0E9952C0C9CC8D2E971A /* SKClient+Account.m */; };
+		052AE2FC96F5F2FA1BED86D111E0F4F0 /* NSDictionary+MTLMappingAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 53DAF85FA8CA77FA6432DD4E4865FA28 /* NSDictionary+MTLMappingAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		05735D40AC69A1FBBDD5DF622B479835 /* AbstractMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 07EAD9F6F9FA6CF821F00410E5793C55 /* AbstractMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		065BB6D4330B794A98798E58C47C06E9 /* SKSnapOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 102BD1F037C4B0705E82FACAADBC648A /* SKSnapOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		06C96BD41A4B7F0388545998F3943C91 /* SKSnap.m in Sources */ = {isa = PBXBuildFile; fileRef = 802057E388A43AE12453D12948E1951C /* SKSnap.m */; };
@@ -27,14 +29,16 @@
 		09475913E1E8F8A5C967C95D101B5748 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0D7CCAAC157EB2E8A7F7A2290A48C89A /* Cocoa.framework */; };
 		0981354675608E7EBD38A6EEBF66B37C /* NSString+SnapchatKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 54460D90C5A5A625598F1A72569A13B5 /* NSString+SnapchatKit.m */; };
 		099696D740CF3C866F1CC938442BFB2D /* SKAddedFriend.h in Headers */ = {isa = PBXBuildFile; fileRef = 65C6A40590103EE3AACC40219CF10B19 /* SKAddedFriend.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0999E6A9C74BDA82BCD8B7CFB54AE488 /* MTLJSONAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D6DA22E10B78E607B571F2A55C30EF9 /* MTLJSONAdapter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		09C58BC21A0FBF1C5429A24448572F2C /* SKClient+Friends.m in Sources */ = {isa = PBXBuildFile; fileRef = A80EB289DF56408DBC3088C043E15245 /* SKClient+Friends.m */; };
 		0B619861F6B430E30337F61DB3F4D4E6 /* ExtendableMessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 151083D0F45656947CF1BAD22F86B9EE /* ExtendableMessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0BB90E81EBAD7A3CC465A757B8380910 /* EXTScope.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D5F2EFE545E38C869A6A2D1EABEFE6F /* EXTScope.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		0BCF2760E68800780670F754593FD6D8 /* WireFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E8F6A76DF1D61C5C7225F9DDCD74CA3 /* WireFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0C30C90656ECBECF298AD0160715EA48 /* NSDictionary+MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DF9455276C69ACF288FDCEEB316B212 /* NSDictionary+MTLJSONKeyPath.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		0C76554583B90F6209F6C1C71908B250 /* MutableField.h in Headers */ = {isa = PBXBuildFile; fileRef = E6B8AC488192EFFE38ABFA7054D5FAE7 /* MutableField.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0CC5E979EB52B9966F2B4E18315DBDC0 /* SKRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = E723F5E599FCD85ABFD4F911E3DDDE5F /* SKRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0CF6E8F089E0B74DC3B3895890C8FB64 /* NSError+MTLModelException.m in Sources */ = {isa = PBXBuildFile; fileRef = A3B3600563469E165A512779D2952B19 /* NSError+MTLModelException.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		0F2D519BD6C421E07B3026992381A769 /* PBArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A69F98F1A3DEA5E52B393E4CA8AEAF9 /* PBArray.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0FDD7201F16809B2433B7543FC6CC530 /* NSValueTransformer+MTLInversionAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FDC119599936009F4BBDAE2B034A189 /* NSValueTransformer+MTLInversionAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		1031F9FEA1EDEE8A92E93180AE933A14 /* CodedInputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 04365EC94A261DF5AA309962BFE4E7AA /* CodedInputStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		10426A8D8C4853EB096DF09D705CA7BA /* ExtensionField.h in Headers */ = {isa = PBXBuildFile; fileRef = 01E0A94D80868EC6EA02AE1C229EAC5D /* ExtensionField.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		10A7A4024E814E076590E646FFF0598B /* SKFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 84C3168646A0D3D84DBEAC87C1C0BDA6 /* SKFilter.m */; };
@@ -50,9 +54,9 @@
 		1841924A876FF2571659ECFD3B1EE210 /* SKSnapOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 102BD1F037C4B0705E82FACAADBC648A /* SKSnapOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		185E6B9D1562C1D1E1A49B73FC1FF46F /* SKStoryNote.m in Sources */ = {isa = PBXBuildFile; fileRef = E7264B33B0A0713CE212280490FD1800 /* SKStoryNote.m */; };
 		185F49393199308807E43E7F2987BF93 /* SKBlob.m in Sources */ = {isa = PBXBuildFile; fileRef = EC153DEC3715CFBB867734E4DCF5C9D6 /* SKBlob.m */; };
+		1A396CAA57FAFE6CB901C87A93904F21 /* EXTScope.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D5F2EFE545E38C869A6A2D1EABEFE6F /* EXTScope.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		1A5975CE8C5E0498D886DEB4452CEEFD /* Utilities.m in Sources */ = {isa = PBXBuildFile; fileRef = E059AC38BADB0D1B36F1843E1BE50C2F /* Utilities.m */; };
 		1A704361620477DAB19E6EBD967D8F24 /* SKFoundFriend.h in Headers */ = {isa = PBXBuildFile; fileRef = 93D7F125345B7EE254042449068E0D63 /* SKFoundFriend.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1B076DF3B4692E545CA4410C3A0B9E70 /* EXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = C994D8C3A0E2BD2F6A50788977A698B4 /* EXTRuntimeExtensions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		1C3E25E616DC7ACDA6A71318B5B97A0B /* SKConversation.m in Sources */ = {isa = PBXBuildFile; fileRef = 979970EC473F3B7EC64A997D0DAB7410 /* SKConversation.m */; };
 		1CCCE7272B85A744EA4BBFF2A2B1A584 /* SKStory.h in Headers */ = {isa = PBXBuildFile; fileRef = B4B133121782FD34737B816B9476DBF9 /* SKStory.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1EB2D4070BDBA437257948E9847CAD45 /* Pods-SnapchatKit_Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = ED040AD1A09159B67F92E0C54034D46E /* Pods-SnapchatKit_Tests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -65,17 +69,16 @@
 		2264E1B7537847FB1E24B6EEE74ED9E3 /* Pods-SnapchatKit_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A5B71C481C0DEFF98AA08BF9328DB8C /* Pods-SnapchatKit_Example-dummy.m */; };
 		2374F497E8C89CB6D8C49233C14F4DC9 /* NSError+MTLModelException.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A4992617DD257BF87C19BD4E5A7D2A9 /* NSError+MTLModelException.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		237F5429A90C1C3874380DFCC7F50349 /* SKSimpleUser.h in Headers */ = {isa = PBXBuildFile; fileRef = E54E26EDFAA3F10A36830DE50A7A5B14 /* SKSimpleUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		23909EA74D814415AD25CAA0D3429E8A /* NSValueTransformer+MTLInversionAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FDC119599936009F4BBDAE2B034A189 /* NSValueTransformer+MTLInversionAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		242F7528027487EBDCAB8DB71CDBB224 /* SKFoundFriend.m in Sources */ = {isa = PBXBuildFile; fileRef = 31E2210149C81E3944A0BE1276CAC3A1 /* SKFoundFriend.m */; };
 		243D3B86A9A67DEFD0BDCEE4D6C7D839 /* ObjectivecDescriptor.pb.h in Headers */ = {isa = PBXBuildFile; fileRef = CDF8D63AD3F269AECF961EB562B4584D /* ObjectivecDescriptor.pb.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2505947A59E09D87EC189986798356C0 /* SKRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9412679689721ADFAAC7A895E02BA5AE /* SKRequest.m */; };
 		2585D6EA8E5FE203C3FC8CB2FEEDF40A /* zip.h in Headers */ = {isa = PBXBuildFile; fileRef = FB2D208BA9563060C0278C6D8F71C479 /* zip.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		25AE841809F8AB20D9F55F85861DA349 /* MessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = E3D463D60137F8318D301057A1ECFDB5 /* MessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		26011E3D61F619D4A9BCEC383FEAC05D /* MTLJSONAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D6DA22E10B78E607B571F2A55C30EF9 /* MTLJSONAdapter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		267CF5C3C42266B456D26CCB8A6AF099 /* SnapchatKit-Constants.h in Headers */ = {isa = PBXBuildFile; fileRef = CE4ABDF04FF8494E1C5D6E053D288B2A /* SnapchatKit-Constants.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2681E46DD69A2B7004A58ADC8E080957 /* CodedOutputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = C166F11F874CC66F155035BD723C973A /* CodedOutputStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		268F4A06D7E5CF71356647535F47A0F0 /* ExtensionRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 37186F3BDEF4361A87EE611FE929CFB9 /* ExtensionRegistry.m */; };
 		26A8FB84B0F7ACB0C5403E4A920A0881 /* SKClient+Device.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E8C22914F0D53BA79853BCCAE38D6A0 /* SKClient+Device.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		27D62862900D1134988F4606B032AA44 /* MTLValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 30966F6B3985DE33FEB91E8D08220629 /* MTLValueTransformer.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		282B53B2BA402322977754FB8714551A /* Mantle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73839BEC40DA572D986E82BD377F57E7 /* Mantle.framework */; };
 		285286FE8C7219404AE1AA0A97E12410 /* MTLReflection.h in Headers */ = {isa = PBXBuildFile; fileRef = 14DA7638F179D4435E88DD761A6C54AF /* MTLReflection.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		285A44F32981BF111E7B69389A567FBC /* UnknownFieldSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FDCF9C141D2B76551E065804EB72AF7 /* UnknownFieldSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -99,6 +102,7 @@
 		2E38B3A0594877C7393F558A96FF21EE /* NSDictionary+MTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = DF085137EB0F35B5B37260EABF2BC4FF /* NSDictionary+MTLManipulationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2F2DBCB99EFB00EC2A9965B8FBB8E91A /* UnknownFieldSetBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 15787D58A018F7C163848E0EDEFFF2AB /* UnknownFieldSetBuilder.m */; };
 		305CEBA9E37E583C6CC9F26CED58F86D /* RingBuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = D7AD70060269B4629B407FE76BD9B976 /* RingBuffer.m */; };
+		3165B0D846A156E1ACBF659BAA4E9F12 /* NSDictionary+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B9085E7485D99346EF2A43B26F8F498 /* NSDictionary+MTLManipulationAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		31A006C7D74D36E484C66524FB9B94E2 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0D7CCAAC157EB2E8A7F7A2290A48C89A /* Cocoa.framework */; };
 		31E7338BAEC9D179702663B3590EFBC2 /* EXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 747032A30F0B0CFAE55E25EE38C28805 /* EXTRuntimeExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		31F9DB362566BA94B17E3D7ACB3D3E0C /* SKSnapResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = DD4D2DD38DC19BF04525CD76056DF23B /* SKSnapResponse.m */; };
@@ -118,6 +122,7 @@
 		375918802120B79CE1A811521FF565C3 /* Descriptor.pb.m in Sources */ = {isa = PBXBuildFile; fileRef = 55BA9EA15DD7130BEC47C5B99EC9384A /* Descriptor.pb.m */; };
 		377B4976BE7CFD109B545F252618C439 /* SKStory.m in Sources */ = {isa = PBXBuildFile; fileRef = 9269F78B7355A85A30F6036EEAAC51C9 /* SKStory.m */; };
 		383508FE12C8DCCB754440DC8687ED7A /* SKSession.h in Headers */ = {isa = PBXBuildFile; fileRef = AA054E5F64577F7C772D73102EF8F7C1 /* SKSession.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3850E499957400FD1BAC9A0109F5EE52 /* MTLModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 21A864CDFDE11D41869495F647850956 /* MTLModel.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		39BA0E82CE3772CCB25D8794CB97340D /* SKClient+Account.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CBC1007B50FB6D8D8CCC49C9AA3A908 /* SKClient+Account.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		39EA28C03534E3CF349C04D02204C43F /* Bootstrap.h in Headers */ = {isa = PBXBuildFile; fileRef = 30F3816561C0672DD603262F36C61EB4 /* Bootstrap.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3A3C6B40096B06D7E7A863D6B449807A /* MTLTransformerErrorHandling.m in Sources */ = {isa = PBXBuildFile; fileRef = B0B3A02E4506C7059D914FEF250427E1 /* MTLTransformerErrorHandling.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
@@ -133,7 +138,6 @@
 		3CB7CF2F1075ADA90CB8E5C99602CC79 /* RingBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 31F648378E994908BE3DEFFBD2CEB0CB /* RingBuffer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3D3F06AB744A95368C463750E4B80D62 /* NSString+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 01D3D233D27189A14C4D48B64946BEDC /* NSString+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3D4B72F09A7D1AF5AC53C83EB21EC908 /* MutableField.m in Sources */ = {isa = PBXBuildFile; fileRef = 709485E58BF2FF0A4C686203BE95E8EB /* MutableField.m */; };
-		3D5C7C244711B6322687777E61E19A6C /* NSDictionary+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B9085E7485D99346EF2A43B26F8F498 /* NSDictionary+MTLManipulationAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		3DAB7FA1643B395E29020DF3DB043FB4 /* SKStoryOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2349A4CD323EDCB9F3445312B2F9489A /* SKStoryOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3DC3166DBA145A9B1A72D3D0E833404D /* MTLValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 18B61B312FEA02DCE16514E7C4A29FBA /* MTLValueTransformer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3E29BB9178E4EDFADCF80C9CD5AD83DD /* NSArray+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 444ABAE227428925EDF5D132A91868E4 /* NSArray+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -148,19 +152,18 @@
 		445F6FE8D9561E076CAFD7F720282A17 /* RingBuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = D7AD70060269B4629B407FE76BD9B976 /* RingBuffer.m */; };
 		44F3B511C9F401D8C16800584A31E61B /* SKClient.h in Headers */ = {isa = PBXBuildFile; fileRef = DE3FD306D6487F5A6E0F63B0BA4493A1 /* SKClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		45D38CB575713150B3A90D9D38ABD156 /* SKStoryCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D74C791C2358D9D5C3D0605B6C1FE5A /* SKStoryCollection.m */; };
-		46204E30E187CD54D9E99E2FAA750AE0 /* MTLModel+NSCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 06373D743A4B8735559065DB34A4D3CF /* MTLModel+NSCoding.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		46250D8FE675647F879F57FA4B5C30A9 /* Utilities.m in Sources */ = {isa = PBXBuildFile; fileRef = E059AC38BADB0D1B36F1843E1BE50C2F /* Utilities.m */; };
 		471BC7DC8B0FABD32EAF770E8D686EB6 /* MTLJSONAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B78B5F838295F2C6CCA0316BE4A7C97 /* MTLJSONAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		473B0B374FDCED388C3F0E90450D56FA /* SKStory.h in Headers */ = {isa = PBXBuildFile; fileRef = B4B133121782FD34737B816B9476DBF9 /* SKStory.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		478331EF4720256BB0BE0CC2A960105C /* MutableExtensionRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DD538EFE6D0B801F385F20D93048AED /* MutableExtensionRegistry.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		479198E6D223F3F7172CE0402F5E2ED2 /* MTLModel+NSCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 06373D743A4B8735559065DB34A4D3CF /* MTLModel+NSCoding.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		486F8E44328E05773A32FABF6363785A /* SKNearbyUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 4825B54E2CDC5AA561EF544825F2A14F /* SKNearbyUser.m */; };
+		488F2949058090EC2188C8E5FA79D184 /* NSObject+MTLComparisonAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 452A825C1C9779653BE134C643213E98 /* NSObject+MTLComparisonAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		4895A72C93179952912E89C31138CEE7 /* WireFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = 4687F307C6DF4771125FACD4FEF41B6F /* WireFormat.m */; };
 		48D9F27D1DF186EEC82DC1323FBDC8BC /* NSValueTransformer+MTLPredefinedTransformerAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = FB0E1FAC0060ECAB08CEE29646BFE32A /* NSValueTransformer+MTLPredefinedTransformerAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		49158774B3216C2C8D3D59F20541A290 /* ProtocolBuffers.h in Headers */ = {isa = PBXBuildFile; fileRef = 5ACEF1C64263788DDF0A871B5FD3415D /* ProtocolBuffers.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4964637AC990C2E5B62511EA4E609D4D /* NSArray+SnapchatKit.m in Sources */ = {isa = PBXBuildFile; fileRef = F20808D5847A1BE5576F1E97363F4126 /* NSArray+SnapchatKit.m */; };
 		49A4D5AABC8F459CEA366B311579E804 /* GeneratedMessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 6192CF7FB23184D714C51581F7A1A1BE /* GeneratedMessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		49F1F759E3211F99AE1EB258A0539A3E /* MTLTransformerErrorHandling.m in Sources */ = {isa = PBXBuildFile; fileRef = B0B3A02E4506C7059D914FEF250427E1 /* MTLTransformerErrorHandling.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		4A4D4EC9627FE511EFBA1983DCA59BBD /* SKClient+Discover.m in Sources */ = {isa = PBXBuildFile; fileRef = 3483A1EC7B5CF9FAD309261F6519CDF3 /* SKClient+Discover.m */; };
 		4AAA0EB9ECD70B397C419509638498B7 /* SKMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 5532B761F50A991D01D8E66810F650B5 /* SKMessage.m */; };
 		4AD59595C51B3FC7C7469B926AB0EED5 /* NSValueTransformer+MTLInversionAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 58BA9F3FC2DC449A0D601CAFBB661733 /* NSValueTransformer+MTLInversionAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -178,9 +181,7 @@
 		4E92A504E5A73DF5D5F8FECEFD6E6F9D /* Message.h in Headers */ = {isa = PBXBuildFile; fileRef = B7ABCBE17F86FB9BEECA8062A041C9AC /* Message.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4EB68C418B69373E07B3B1E76E4361FD /* unzip.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FE550472E08ABD8D5B741D1077F61BA /* unzip.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4EC0C4AB25A9E263DDD76006DC34FE1A /* SKSimpleUser.m in Sources */ = {isa = PBXBuildFile; fileRef = C2CC45708F858B3A21FA14F2C3AE0C49 /* SKSimpleUser.m */; };
-		500930FB6D697F545409818C0A93179B /* NSArray+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = B29E8F6A2790D070998F9CF5CF7EE4D1 /* NSArray+MTLManipulationAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		50915B525DD3E78E926D1A1AC5F72B09 /* NSError+MTLModelException.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A4992617DD257BF87C19BD4E5A7D2A9 /* NSError+MTLModelException.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		516823A4FA02BBC792E37395AD1B85DB /* MTLModel+NSCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 06373D743A4B8735559065DB34A4D3CF /* MTLModel+NSCoding.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		527E54842FB111C7860FFB9DF6FB9480 /* SKUser.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DA60CBC900C38B9E72F99E56E639C3E /* SKUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		53C8EBF58BACE87EA90FA1EA39E6ADBD /* SKThing.m in Sources */ = {isa = PBXBuildFile; fileRef = 9172B364044C193573346831B47E3C32 /* SKThing.m */; };
 		54F2E6E1B8A6294B557119AAC804BBA8 /* zip.h in Headers */ = {isa = PBXBuildFile; fileRef = FB2D208BA9563060C0278C6D8F71C479 /* zip.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -197,6 +198,7 @@
 		5A4FCB51BD6040760589B70D51EA7F6A /* UnknownFieldSetBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 15787D58A018F7C163848E0EDEFFF2AB /* UnknownFieldSetBuilder.m */; };
 		5AA3C1936A3820D8E9BC1D8FE05DE37A /* AbstractMessageBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = C1F491F9A8489CC37E4E1795E1924489 /* AbstractMessageBuilder.m */; };
 		5AE8A38561CDA0A9351FFAC780B75A01 /* ExtensionRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 06B966634B688674E5961D625443E7E4 /* ExtensionRegistry.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B896FA68AEE9209B02BD5A1A58ED398 /* NSValueTransformer+MTLInversionAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FDC119599936009F4BBDAE2B034A189 /* NSValueTransformer+MTLInversionAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		5BC30758F4D0C0F36B721AE29E3A8C1E /* SKNewConversation.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A537E793DA2330169541319E2AD1A2A /* SKNewConversation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5BF56770C12DFAE89B57DA8727C62793 /* SKBlob.m in Sources */ = {isa = PBXBuildFile; fileRef = EC153DEC3715CFBB867734E4DCF5C9D6 /* SKBlob.m */; };
 		5C29A130746FB6D5E84BDBBBF3959E8F /* AbstractMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 07EAD9F6F9FA6CF821F00410E5793C55 /* AbstractMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -210,24 +212,27 @@
 		5F84E4E611C94A8833A393198E0C439C /* MTLModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 21A864CDFDE11D41869495F647850956 /* MTLModel.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		601840AF945E6DAD9409D9F4AC0F84D2 /* Bootstrap.h in Headers */ = {isa = PBXBuildFile; fileRef = 30F3816561C0672DD603262F36C61EB4 /* Bootstrap.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		63912A16DF657113B7EDADE0FC3FA65B /* ExtendableMessageBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D2C9634F9F032DDCBE25B9910E30A5A /* ExtendableMessageBuilder.m */; };
+		6408239CE05D0CBC8D45E28E3CCF95F3 /* NSArray+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = B29E8F6A2790D070998F9CF5CF7EE4D1 /* NSArray+MTLManipulationAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		6563A9DA69FA273918AE1C64F500EACB /* SKSimpleUser.h in Headers */ = {isa = PBXBuildFile; fileRef = E54E26EDFAA3F10A36830DE50A7A5B14 /* SKSimpleUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		65B5A153711F61BF0D37FC0DD0C36E07 /* Descriptor.pb.m in Sources */ = {isa = PBXBuildFile; fileRef = 55BA9EA15DD7130BEC47C5B99EC9384A /* Descriptor.pb.m */; };
 		65C3BB92487BB24C522222F5FA511BD8 /* NSValueTransformer+MTLPredefinedTransformerAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = FB0E1FAC0060ECAB08CEE29646BFE32A /* NSValueTransformer+MTLPredefinedTransformerAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		65DA0ECAF7EBF7CBD51756BC66566B9B /* MTLValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 30966F6B3985DE33FEB91E8D08220629 /* MTLValueTransformer.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		65FC258BEA145736F4CB9C917DCC5DFC /* SKSharedStoryDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 783EA1ECC5FDE5F2CB4C6E1B8B5B9896 /* SKSharedStoryDescription.m */; };
 		67406B8865F4919851BAC6BEA7A0B167 /* CodedOutputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = C166F11F874CC66F155035BD723C973A /* CodedOutputStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		675B22E93193447D18446E3DE8E25257 /* AbstractMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E3B442CA4C99021E31A08D4467D4203 /* AbstractMessage.m */; };
+		67850AD9F804B9C25549DBC296068694 /* NSDictionary+MTLMappingAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 53DAF85FA8CA77FA6432DD4E4865FA28 /* NSDictionary+MTLMappingAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		67EDC13AA60ABBB65208A5082E762C7F /* TextFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 70A50AB4E7409F7A938AA8915CE5522B /* TextFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		686810271159BBFDCF6575E22E786E36 /* Pods-SnapchatKit-OSX-Mantle-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = ADC019666AAF7D7A212B5577793A36B8 /* Pods-SnapchatKit-OSX-Mantle-dummy.m */; };
 		686FF1CB34E4F0795A39A5D74E18077E /* ObjectivecDescriptor.pb.m in Sources */ = {isa = PBXBuildFile; fileRef = 4149CC5EE78E849EAF5DEEFEE5B0AA66 /* ObjectivecDescriptor.pb.m */; };
+		68A2BB69EEF9DCFE5A66D45C2C3E5839 /* NSError+MTLModelException.m in Sources */ = {isa = PBXBuildFile; fileRef = A3B3600563469E165A512779D2952B19 /* NSError+MTLModelException.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		6916DEC99C867F68C2420A0AD0DFA9FA /* SnapchatKit-Constants.h in Headers */ = {isa = PBXBuildFile; fileRef = CE4ABDF04FF8494E1C5D6E053D288B2A /* SnapchatKit-Constants.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6A46FDF31F2E0E67ED93E71F670DFDBA /* NSDictionary+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B9085E7485D99346EF2A43B26F8F498 /* NSDictionary+MTLManipulationAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		6A575A24FA4ABF4977806083C259B579 /* SKSharedStoryDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = E6316AA0C110D87D7C0CEE4F992074FC /* SKSharedStoryDescription.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6ABE31A4D998B09A454798764523FD90 /* ExtensionField.h in Headers */ = {isa = PBXBuildFile; fileRef = 01E0A94D80868EC6EA02AE1C229EAC5D /* ExtensionField.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6B06F02EAB08ABD063C624BC18BA5440 /* AbstractMessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 978BF2612AD5B68A7A65BE361CCDD3DB /* AbstractMessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6B2824B75691F9C3DE9D89565AD14BCB /* SKSimpleUser.m in Sources */ = {isa = PBXBuildFile; fileRef = C2CC45708F858B3A21FA14F2C3AE0C49 /* SKSimpleUser.m */; };
 		6B5ADCF1533B10E43C05B60BC9C49316 /* NSDictionary+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 523519361513D98C2F08E815B11DEF1B /* NSDictionary+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6BA8B54DDCA21FFF73BD889120B17A56 /* MTLJSONAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D6DA22E10B78E607B571F2A55C30EF9 /* MTLJSONAdapter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		6C12BAE728E410C79932652980B431FF /* SKLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 25B50FC7D431013529A4EDF7982F6C0A /* SKLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6CD5886E1C8F03E20962E8E3CBFFFD46 /* NSArray+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = B29E8F6A2790D070998F9CF5CF7EE4D1 /* NSArray+MTLManipulationAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		6CFFFE8D066AC8A212E4332495A030E4 /* SKStoryOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = C889F248D1DED2AFD880A16BC306586F /* SKStoryOptions.m */; };
 		6D0A5F989BECD7803E4C9FCA9E64E663 /* SKStoryUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = 774C527EA09A09E0D8CD014D643D2268 /* SKStoryUpdater.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6D1C5179324E2197B925BE33548A8E0B /* MTLModel+NSCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = D917EDD76808D4D21F22960E1DE309C8 /* MTLModel+NSCoding.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -239,10 +244,8 @@
 		6E8A9BA92639A36DBC0DE93AE0DD78F0 /* NSArray+SnapchatKit.m in Sources */ = {isa = PBXBuildFile; fileRef = F20808D5847A1BE5576F1E97363F4126 /* NSArray+SnapchatKit.m */; };
 		6EEAE3619B32B34D36ED8AA78DB1A0CA /* MTLTransformerErrorHandling.h in Headers */ = {isa = PBXBuildFile; fileRef = C93DEA42EF984A92E5FFF4F5EA4C4576 /* MTLTransformerErrorHandling.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6EF72229A34E368590361CD0ACD79418 /* SKClient+Friends.h in Headers */ = {isa = PBXBuildFile; fileRef = 833D0F7844FB6F9844FF13EF09871134 /* SKClient+Friends.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6FC9297284E6B97475C34E5F64955D1B /* MTLModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 21A864CDFDE11D41869495F647850956 /* MTLModel.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		707CC0B1ABAEC59B775DCB7995E91EB1 /* SKSnapResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FBEB3B3FA6CC7990C60F15777A0090E /* SKSnapResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		70BCAD21362565B8B6FCE6B313D64E2A /* unzip.c in Sources */ = {isa = PBXBuildFile; fileRef = E76B54A5B681A52C9BF1A48F75B3DE3F /* unzip.c */; };
-		713AE4F662C0ABD9A6AB9CCA7E789BC9 /* NSDictionary+MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DF9455276C69ACF288FDCEEB316B212 /* NSDictionary+MTLJSONKeyPath.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		720495FE298D1E150AD5D7841C6CDABB /* Message.h in Headers */ = {isa = PBXBuildFile; fileRef = B7ABCBE17F86FB9BEECA8062A041C9AC /* Message.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		735EC43FFF3F2E70EFAB009963F395E0 /* NSValueTransformer+MTLInversionAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 58BA9F3FC2DC449A0D601CAFBB661733 /* NSValueTransformer+MTLInversionAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		73606C0786F1540F0BA82FBF2174115F /* SKSnap.h in Headers */ = {isa = PBXBuildFile; fileRef = 48D10AA8FB91C836871332883EEE8C79 /* SKSnap.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -256,21 +259,17 @@
 		77750DA27BF7879D82B4EE3D52E43510 /* mztools.h in Headers */ = {isa = PBXBuildFile; fileRef = 1685FA7977E1A72A8CA039CF99A88D23 /* mztools.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7787D715B0932EC381A7A217503C81D3 /* crypt.h in Headers */ = {isa = PBXBuildFile; fileRef = 79F59B49CE4DC99DF440AE4D85E72F6C /* crypt.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		77B17F032EAA511415272130D4FFE432 /* SKLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 25B50FC7D431013529A4EDF7982F6C0A /* SKLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		77EC3AD9A16F93D2A99FA7E24077B4C2 /* NSDictionary+MTLMappingAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 53DAF85FA8CA77FA6432DD4E4865FA28 /* NSDictionary+MTLMappingAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		787F037EADA4F6E7F5441812EB9DB78B /* SKClient+Snaps.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FEA67B46E224685AD9C805D1A27E5D9 /* SKClient+Snaps.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		79969FA9CFC3C2C847770EF64F44D45F /* NSData+SnapchatKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AC6595E4B0F1881632644CBC0879775 /* NSData+SnapchatKit.m */; };
-		79A99170C7433CE688B43AC977697B2C /* NSError+MTLModelException.m in Sources */ = {isa = PBXBuildFile; fileRef = A3B3600563469E165A512779D2952B19 /* NSError+MTLModelException.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		7A26BB491B363D1023D7446361049660 /* Pods-SnapchatKit-OSX-SnapchatKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C1655D290963794DB4DD8A91377BAC2E /* Pods-SnapchatKit-OSX-SnapchatKit-dummy.m */; };
 		7AEFF01882B6D07EA6C6575E714E7ECE /* SKLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 81A6A60094231EA88DCE60750AA13AE1 /* SKLocation.m */; };
 		7AF32F69DFF9CD3A4BDBB7538E278E17 /* unzip.c in Sources */ = {isa = PBXBuildFile; fileRef = E76B54A5B681A52C9BF1A48F75B3DE3F /* unzip.c */; };
 		7B985DA5AD90B39433D3D9A6861B640F /* Pods-SnapchatKit-OSX-Mantle-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 400621EB0B2F9F65897A439566594B63 /* Pods-SnapchatKit-OSX-Mantle-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7BE6E040D3F1AC607295260C3C909DE4 /* Field.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DC6C59C7DEA6461C564B1DA58829542 /* Field.m */; };
 		7C18CDA8B0EBA841F87ABB1611FF8B20 /* ProtocolBuffers.h in Headers */ = {isa = PBXBuildFile; fileRef = 5ACEF1C64263788DDF0A871B5FD3415D /* ProtocolBuffers.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7CDB177F22682CBFA481206CADF09D37 /* NSDictionary+MTLMappingAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 53DAF85FA8CA77FA6432DD4E4865FA28 /* NSDictionary+MTLMappingAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		7CEC7865664510578601198B6481E6FA /* Pods-SnapchatKit_Tests-SnapchatKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D5738FF9A898F9686A3AE9C8BF64405A /* Pods-SnapchatKit_Tests-SnapchatKit-dummy.m */; };
 		7D375F95240E56B49AB9246BEBBAAF0A /* SKSnapOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F8EFE9CDCA52EC0CCBD1DF32DA061F4 /* SKSnapOptions.m */; };
 		7D4EE1042363324DF6F26740E061D54E /* mztools.c in Sources */ = {isa = PBXBuildFile; fileRef = 884007D97EAC905D528F2D798D498CA3 /* mztools.c */; };
-		7D91CF1B01A4BE4B453227A680729D21 /* MTLModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 21A864CDFDE11D41869495F647850956 /* MTLModel.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		7D99ECA077EFE880E6E2A0663B9773AD /* NSArray+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 444ABAE227428925EDF5D132A91868E4 /* NSArray+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7DB4E5D0DDEABF686A3A81C9120774AB /* NSArray+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 444ABAE227428925EDF5D132A91868E4 /* NSArray+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7DB7BEADB3E60310D8E4EA2166130CFB /* SKStoryCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = 45A8B9B178D3D50255BED3D0FCB98A78 /* SKStoryCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -282,7 +281,6 @@
 		800B2ECD46D46FC159315AF31AF610B8 /* SKSnapResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FBEB3B3FA6CC7990C60F15777A0090E /* SKSnapResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		803F89A1C505A07F75F3306D28C3A5C7 /* MutableField.m in Sources */ = {isa = PBXBuildFile; fileRef = 709485E58BF2FF0A4C686203BE95E8EB /* MutableField.m */; };
 		80AE9C745A522B06E97A31691EBC686D /* SKClient+Discover.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B6CEADD2D0C33311B5DF1F367E954A5 /* SKClient+Discover.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		80C63601371D20829F892DC9CA8CC421 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = A7E0035C4D44DD28CDC29DBEE88C9580 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		80D3C4F20263F275FA6E5D497B2C2978 /* PBArray.m in Sources */ = {isa = PBXBuildFile; fileRef = 80833A66B09D6D42B65135FA200C959A /* PBArray.m */; };
 		80E3A5718419A00654103E2D76C40DC7 /* AbstractMessageBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = C1F491F9A8489CC37E4E1795E1924489 /* AbstractMessageBuilder.m */; };
 		81153517E47875ECCC70490FB290980A /* Message.h in Headers */ = {isa = PBXBuildFile; fileRef = B7ABCBE17F86FB9BEECA8062A041C9AC /* Message.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -290,9 +288,9 @@
 		818A50C74A4222067AE1AB8D86B9A24A /* SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E8E9BC41A16B11C168D078CD7578264 /* SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		82230F3D2FDC4B015A8164933ABE29EC /* TextFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = D7120C8C40EF2A6454683D2023AA4521 /* TextFormat.m */; };
 		82322A79FF610A7A075BE4404714E3C4 /* MTLModel+NSCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = D917EDD76808D4D21F22960E1DE309C8 /* MTLModel+NSCoding.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		828CDEC7DFB75BD78C84DB785597E016 /* NSObject+MTLComparisonAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 452A825C1C9779653BE134C643213E98 /* NSObject+MTLComparisonAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		82946214B08EC20BF2FB024EFBF99340 /* NSString+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 01D3D233D27189A14C4D48B64946BEDC /* NSString+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		82C521B31AAC7DFD5D18E618BFBF06CF /* SKClient+Chat.h in Headers */ = {isa = PBXBuildFile; fileRef = 97ABC90E3828E9031BC4F158D4F3EEE2 /* SKClient+Chat.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		82D808B2D325BA2A254E565C8F6CC555 /* NSValueTransformer+MTLInversionAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FDC119599936009F4BBDAE2B034A189 /* NSValueTransformer+MTLInversionAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		8329E0046C4D88212E52F57626494008 /* NSObject+MTLComparisonAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 452A825C1C9779653BE134C643213E98 /* NSObject+MTLComparisonAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		8369D6BE3B24E83F01D6B117792A1C68 /* NSObject+MTLComparisonAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 90E3A46DADAE808ABCF8DA093A1F0A37 /* NSObject+MTLComparisonAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		83B2581466924E92C1A63FA109400294 /* MTLJSONAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B78B5F838295F2C6CCA0316BE4A7C97 /* MTLJSONAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -302,7 +300,6 @@
 		853344F944576EF29BF0925C878D23D8 /* UnknownFieldSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FDCF9C141D2B76551E065804EB72AF7 /* UnknownFieldSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		85DB71B674B21FC4069B3172E010757F /* SKLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 25B50FC7D431013529A4EDF7982F6C0A /* SKLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		86319C7A3EED59A06A3A15D78B09693B /* ExtensionRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 06B966634B688674E5961D625443E7E4 /* ExtensionRegistry.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8658349B9E14201EDFD7D4697801AB42 /* NSDictionary+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B9085E7485D99346EF2A43B26F8F498 /* NSDictionary+MTLManipulationAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		8693A017630AD73BE9AE77857D0BB232 /* WireFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E8F6A76DF1D61C5C7225F9DDCD74CA3 /* WireFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		86A7957E1DB85234A4BBA94F8CE796A4 /* SKSession.h in Headers */ = {isa = PBXBuildFile; fileRef = AA054E5F64577F7C772D73102EF8F7C1 /* SKSession.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8745E60DE9438702B88C9FA9D8DA0DCC /* NSObject+MTLComparisonAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 90E3A46DADAE808ABCF8DA093A1F0A37 /* NSObject+MTLComparisonAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -322,6 +319,7 @@
 		8B56ECEF3192D42F101031F657E5A880 /* ForwardDeclarations.h in Headers */ = {isa = PBXBuildFile; fileRef = 67B7031A1CFE11F0B693963D8F04BA39 /* ForwardDeclarations.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8B65A25E3DB1397009D9C6CCB10A9C1C /* SKSimpleUser.m in Sources */ = {isa = PBXBuildFile; fileRef = C2CC45708F858B3A21FA14F2C3AE0C49 /* SKSimpleUser.m */; };
 		8B75EDAFEAD28F8D92FE8216A16888FC /* SKThing.h in Headers */ = {isa = PBXBuildFile; fileRef = E9AF192BD8DD526AEB6FD5A02EEB2A56 /* SKThing.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8C256964C1A9CAB8514584772DD9A9EB /* EXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = C994D8C3A0E2BD2F6A50788977A698B4 /* EXTRuntimeExtensions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		8C2B5C50D6D72F51C6240F7F9750A892 /* NSValueTransformer+MTLInversionAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FDC119599936009F4BBDAE2B034A189 /* NSValueTransformer+MTLInversionAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		8C4E7CA7C2ECD97C9848176090E0F4D6 /* GeneratedMessageBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 463D5934C525845DDF6D4108DF174801 /* GeneratedMessageBuilder.m */; };
 		8CD58B6E46D98F6B469F0D53E56F3142 /* AbstractMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E3B442CA4C99021E31A08D4467D4203 /* AbstractMessage.m */; };
@@ -330,8 +328,11 @@
 		8DB774211405DA6D9DC3AC9B4BF3AB59 /* MTLJSONAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B78B5F838295F2C6CCA0316BE4A7C97 /* MTLJSONAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8E02D789287764E4CDF11A66546B5030 /* CodedInputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = D64A94D4DFB38E5653DD76D20218BE09 /* CodedInputStream.m */; };
 		8ED0BD420D3AB8E37C06CFBADABBC5CC /* ConcreteExtensionField.h in Headers */ = {isa = PBXBuildFile; fileRef = 6826B1CCA448E90716D8C1B6E74BC68B /* ConcreteExtensionField.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9013316F80ACF1D91D90B340AB16D7EA /* EXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = C994D8C3A0E2BD2F6A50788977A698B4 /* EXTRuntimeExtensions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		906785162BA8A0D06C02C4EEF497F3AB /* MTLModel+NSCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 06373D743A4B8735559065DB34A4D3CF /* MTLModel+NSCoding.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		90890CCD9FAFA3E17B7F50715A030987 /* SKConversation.m in Sources */ = {isa = PBXBuildFile; fileRef = 979970EC473F3B7EC64A997D0DAB7410 /* SKConversation.m */; };
 		908A58094D68486876A366AFC5589582 /* MTLTransformerErrorHandling.h in Headers */ = {isa = PBXBuildFile; fileRef = C93DEA42EF984A92E5FFF4F5EA4C4576 /* MTLTransformerErrorHandling.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		90B289988B70AE68D7A33F72FF79E7D4 /* NSArray+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = B29E8F6A2790D070998F9CF5CF7EE4D1 /* NSArray+MTLManipulationAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		9121F000E62DE87B8CF8DA11EA769789 /* ConcreteExtensionField.h in Headers */ = {isa = PBXBuildFile; fileRef = 6826B1CCA448E90716D8C1B6E74BC68B /* ConcreteExtensionField.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9132D10211BE3A8EF9BD2A643A5980D6 /* NSValueTransformer+MTLPredefinedTransformerAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = FB0E1FAC0060ECAB08CEE29646BFE32A /* NSValueTransformer+MTLPredefinedTransformerAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		915FB623F1795824405471A9F6BA53F1 /* SKConversation.h in Headers */ = {isa = PBXBuildFile; fileRef = FEBB2E828CE404D19FE3169CB4CE45B6 /* SKConversation.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -359,7 +360,6 @@
 		996AA48FF48E0EF26C5E5317AD160D65 /* SKRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = E723F5E599FCD85ABFD4F911E3DDDE5F /* SKRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		997674D7B460BEF3BB195BEB8327B01E /* GeneratedMessageBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 463D5934C525845DDF6D4108DF174801 /* GeneratedMessageBuilder.m */; };
 		9A3EBC3748D4F4F48DA2A0133A438B36 /* Pods-SnapchatKit_Example-Mantle-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = BA7F4D5E4C8595A3D1AE0EB307C2CB8E /* Pods-SnapchatKit_Example-Mantle-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9A99F08C293A16C31870858C276DFD94 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = A7E0035C4D44DD28CDC29DBEE88C9580 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		9B97BEF2E3CBC1E97617A003F1B98E0A /* SKClient+Stories.m in Sources */ = {isa = PBXBuildFile; fileRef = 9AAF0F4CF61FEBE5F27F076EE43534B6 /* SKClient+Stories.m */; };
 		9BD5C2540AB3E6938E65AF75410E336F /* SKUserStory.m in Sources */ = {isa = PBXBuildFile; fileRef = EBF31098D1B73D4027EF54C1B7EC55E7 /* SKUserStory.m */; };
 		9BD952A5A55EBB202F43317F9835BD07 /* Field.h in Headers */ = {isa = PBXBuildFile; fileRef = AEA4DB5D58231D27AC6CDE90D7240533 /* Field.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -390,6 +390,7 @@
 		A69CF9AB373B5BF54933D4BCBDD24B8A /* MutableField.h in Headers */ = {isa = PBXBuildFile; fileRef = E6B8AC488192EFFE38ABFA7054D5FAE7 /* MutableField.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A6CD5AF026F0476BFA019BA291B70CA1 /* Pods-SnapchatKit_Tests-Mantle-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A362FEDA412E6EA8B1971C25C70FDA47 /* Pods-SnapchatKit_Tests-Mantle-dummy.m */; };
 		A6DB9B2A5EBA640EC7ABDE1CDF72CFCC /* UnknownFieldSetBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = F4B5E1A7AAE7E607AC9E54D4FA333BAB /* UnknownFieldSetBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A7579F506B62E5A6FC1AD11F61843AB5 /* NSDictionary+MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DF9455276C69ACF288FDCEEB316B212 /* NSDictionary+MTLJSONKeyPath.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		A75E694DA35CE46237D3311DDAF8E8E9 /* SKThing.m in Sources */ = {isa = PBXBuildFile; fileRef = 9172B364044C193573346831B47E3C32 /* SKThing.m */; };
 		A95A1AE1DE0E8B75BF1A203BFFAC2595 /* NSArray+MTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 06531AAEF120FF70E927F40F0A61C49D /* NSArray+MTLManipulationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA0BD7F44E7BEB9A8E6D5B83E7CBA2C0 /* SKUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 5515DC27DAB5541F75B0AA3425061AAE /* SKUser.m */; };
@@ -405,6 +406,7 @@
 		AF2B8C4FFD7B9FDFBFB1F27C0054ED5C /* AbstractMessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 978BF2612AD5B68A7A65BE361CCDD3DB /* AbstractMessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AF454BAAC58CB4B904C62B393C392345 /* mztools.c in Sources */ = {isa = PBXBuildFile; fileRef = 884007D97EAC905D528F2D798D498CA3 /* mztools.c */; };
 		AF603D752936B17358AB6FF4246D6C09 /* Attestation.pb.m in Sources */ = {isa = PBXBuildFile; fileRef = 606FE432D85DF39B09C3DE7E82B31AD7 /* Attestation.pb.m */; };
+		AF6C8CFE2A8CC031E4F875E0D65B0505 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = A7E0035C4D44DD28CDC29DBEE88C9580 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		B0C4CE31D4BA47F6DF5A10AC79DC3A6A /* SKCashTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A0F9C65CF3106FAC238CDC512FF51E2 /* SKCashTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B0C615AECE49899C2361FDFBBD35CAB7 /* SKBlob.m in Sources */ = {isa = PBXBuildFile; fileRef = EC153DEC3715CFBB867734E4DCF5C9D6 /* SKBlob.m */; };
 		B0D9197026A81388B71196FFF4D5BB06 /* crypt.h in Headers */ = {isa = PBXBuildFile; fileRef = 79F59B49CE4DC99DF440AE4D85E72F6C /* crypt.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -412,7 +414,6 @@
 		B15127483D4E7BEB3DD36CCED6617C8C /* Field.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DC6C59C7DEA6461C564B1DA58829542 /* Field.m */; };
 		B1B806F787A2841D03ADB6E235DB5756 /* Mantle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73839BEC40DA572D986E82BD377F57E7 /* Mantle.framework */; };
 		B27523C2DE3F1E3134712528C0F750A4 /* Field.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DC6C59C7DEA6461C564B1DA58829542 /* Field.m */; };
-		B28D218A54569D6D4E6242C19557860F /* EXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = C994D8C3A0E2BD2F6A50788977A698B4 /* EXTRuntimeExtensions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		B300232873C207599BBB51BE2CDA97B6 /* SKClient+Device.m in Sources */ = {isa = PBXBuildFile; fileRef = DDF462ACA7D6BE321BE504088CFC8EC9 /* SKClient+Device.m */; };
 		B34DA3C60AFDAAAEA2C27A5D5C45763D /* SKRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = E723F5E599FCD85ABFD4F911E3DDDE5F /* SKRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B3AD53F71382D3CCDFFBF55DFAA15121 /* SKStoryNote.m in Sources */ = {isa = PBXBuildFile; fileRef = E7264B33B0A0713CE212280490FD1800 /* SKStoryNote.m */; };
@@ -426,9 +427,9 @@
 		B9FB2048F4E99A5867CC972C0CDCD527 /* SKUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 5515DC27DAB5541F75B0AA3425061AAE /* SKUser.m */; };
 		BAED1E04C71874842555DB3B7C492E26 /* SKCashTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = F33789AB1CD889C76EE417221D59C3D9 /* SKCashTransaction.m */; };
 		BBD51C8B83ED3761DD5A40F120427D25 /* SKNearbyUser.h in Headers */ = {isa = PBXBuildFile; fileRef = AF2BABB30D0A63B528450704A8CC4831 /* SKNearbyUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BD4E59EDF409CBFD9D9728ACF6AA5881 /* EXTScope.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D5F2EFE545E38C869A6A2D1EABEFE6F /* EXTScope.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		BE331BBE584C5DDA5061F18B0DBD43F7 /* RingBuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = D7AD70060269B4629B407FE76BD9B976 /* RingBuffer.m */; };
 		BF596A9358398FD70766E2748274387F /* Pods-SnapchatKit_Example-Mantle-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = CBA1FDCD70D710D40E0FEE2504BB4C9B /* Pods-SnapchatKit_Example-Mantle-dummy.m */; };
+		BFB50EB3EDD355B13E36D6DFAAABFC07 /* MTLModel+NSCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 06373D743A4B8735559065DB34A4D3CF /* MTLModel+NSCoding.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		BFEF6C043A14EAA70813835B40CD4868 /* SKFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 84C3168646A0D3D84DBEAC87C1C0BDA6 /* SKFilter.m */; };
 		C0890754A06E690B5CF7779383382159 /* SKFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 84C3168646A0D3D84DBEAC87C1C0BDA6 /* SKFilter.m */; };
 		C0C929E4ACF3F3B5708EED5A60383238 /* WireFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E8F6A76DF1D61C5C7225F9DDCD74CA3 /* WireFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -438,6 +439,7 @@
 		C253F506F8C862B9018A0587DB20A7E0 /* SnapchatKit-Constants.h in Headers */ = {isa = PBXBuildFile; fileRef = CE4ABDF04FF8494E1C5D6E053D288B2A /* SnapchatKit-Constants.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C36799F94CDBC5D09A98A0A547AD3509 /* mztools.c in Sources */ = {isa = PBXBuildFile; fileRef = 884007D97EAC905D528F2D798D498CA3 /* mztools.c */; };
 		C439369054238B8A0E00645EDEAF398F /* SKClient+Account.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CBC1007B50FB6D8D8CCC49C9AA3A908 /* SKClient+Account.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C48D966383CB72397DFCE90FC2169A44 /* MTLReflection.m in Sources */ = {isa = PBXBuildFile; fileRef = 6549D674C4BBFC4AE9F553D4ABED4F95 /* MTLReflection.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		C5162F5ED425FB21237997AE5CC4898A /* SKCashTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = F33789AB1CD889C76EE417221D59C3D9 /* SKCashTransaction.m */; };
 		C5FAD05BFDDA22A0AB15ECCB8629965A /* SKClient+Device.m in Sources */ = {isa = PBXBuildFile; fileRef = DDF462ACA7D6BE321BE504088CFC8EC9 /* SKClient+Device.m */; };
 		C645928E34D41BA10A71023575AF62E7 /* SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E8E9BC41A16B11C168D078CD7578264 /* SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -455,8 +457,9 @@
 		CCDC21DA0FAB1837A8D4D94E3051457E /* ExtendableMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 00655651C6BA81463B1F1AC19D408EFB /* ExtendableMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CDDDA9F0CAA7C9B3D08CFBD9B9ABCDB4 /* MTLValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 18B61B312FEA02DCE16514E7C4A29FBA /* MTLValueTransformer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CDFE542F4E6B55DB53B4C16C500C328A /* unzip.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FE550472E08ABD8D5B741D1077F61BA /* unzip.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CE05F613D4B6C6F6F13C5237ED8DD23F /* NSDictionary+MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DF9455276C69ACF288FDCEEB316B212 /* NSDictionary+MTLJSONKeyPath.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		CF2FDC3BE87FF50F5030F93491656E0E /* MTLModel+NSCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = D917EDD76808D4D21F22960E1DE309C8 /* MTLModel+NSCoding.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CFCED157CD10D394DB19A3A73845D397 /* MTLTransformerErrorHandling.m in Sources */ = {isa = PBXBuildFile; fileRef = B0B3A02E4506C7059D914FEF250427E1 /* MTLTransformerErrorHandling.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		CFDC763E5EEB85D70D2ECF4145F5193E /* MTLModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 21A864CDFDE11D41869495F647850956 /* MTLModel.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		CFE6FA04E3BA20BAAA7D29D16E21DFB7 /* SSZipArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = 864E8CC81A76CA838F6299352A05BC9D /* SSZipArchive.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D0E98E6916C59A771CE7C86D511FD055 /* CodedInputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = D64A94D4DFB38E5653DD76D20218BE09 /* CodedInputStream.m */; };
 		D1465806DEA963CAA3584333FA6D75A7 /* PBArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A69F98F1A3DEA5E52B393E4CA8AEAF9 /* PBArray.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -464,7 +467,6 @@
 		D1AB726477E70D4EC3B9A717E4D2433F /* UnknownFieldSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FDCF9C141D2B76551E065804EB72AF7 /* UnknownFieldSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D1C5FB6E0C236942AFE5AAA5AAFF5655 /* CodedInputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 04365EC94A261DF5AA309962BFE4E7AA /* CodedInputStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D1E0716F92E6511E55B5B96ED4AEC4C8 /* Bootstrap.h in Headers */ = {isa = PBXBuildFile; fileRef = 30F3816561C0672DD603262F36C61EB4 /* Bootstrap.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D209D6CC69F6B7EBEDBB9B94FC2B1553 /* MTLValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 30966F6B3985DE33FEB91E8D08220629 /* MTLValueTransformer.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		D23DDBDFBAE8C4C9A5716B13D3FAA378 /* MTLModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 35985918E56AD9E0C441B57EF60B263E /* MTLModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D282D374F9873392A05853818A6D5B0E /* Attestation.pb.h in Headers */ = {isa = PBXBuildFile; fileRef = C90F6DCB8E6D5E5AD3B2C839EDF984C8 /* Attestation.pb.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D2F78FAE5B3A0C938FB4B80EBF1923B3 /* Pods-SnapchatKit_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FAFA003B01F71668975B806F52809BB /* Pods-SnapchatKit_Tests-dummy.m */; };
@@ -491,7 +493,6 @@
 		D9AE24C66EC8F86F6C6794256914021E /* NSDictionary+MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DF9455276C69ACF288FDCEEB316B212 /* NSDictionary+MTLJSONKeyPath.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		DA14ED2CE15397202863A58835616AE0 /* SKClient+Snaps.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FEA67B46E224685AD9C805D1A27E5D9 /* SKClient+Snaps.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA15C7DBB4AF9459D0BF6660F61E11AD /* SKLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 81A6A60094231EA88DCE60750AA13AE1 /* SKLocation.m */; };
-		DA2AB6464AEFC1DBE969E84F5836188F /* NSObject+MTLComparisonAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 452A825C1C9779653BE134C643213E98 /* NSObject+MTLComparisonAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		DAF7AF94D28CAFD1ED64657BAFF890D4 /* GeneratedMessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 6192CF7FB23184D714C51581F7A1A1BE /* GeneratedMessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DB1EA51D93B03B1F6996245180D5781A /* UnknownFieldSetBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 15787D58A018F7C163848E0EDEFFF2AB /* UnknownFieldSetBuilder.m */; };
 		DBD779589C0EEF217F9BD85A4488DF71 /* ObjectivecDescriptor.pb.h in Headers */ = {isa = PBXBuildFile; fileRef = CDF8D63AD3F269AECF961EB562B4584D /* ObjectivecDescriptor.pb.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -500,20 +501,19 @@
 		DC2BD42E5AE0E113899FE3A995FB94B9 /* EXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 747032A30F0B0CFAE55E25EE38C28805 /* EXTRuntimeExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DCBC7AE273C3D00ED094C5FA527956CA /* SKClient+Stories.h in Headers */ = {isa = PBXBuildFile; fileRef = CEB772F1CD2E64A93211D413F991E158 /* SKClient+Stories.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DD262F615BA14F4CF16F59966D429D03 /* CodedOutputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = AA7B9832442745B728000CCF09AD59A2 /* CodedOutputStream.m */; };
-		DEA5708CAC1F0A0CB8A7F6BD2F04CC7C /* MTLReflection.m in Sources */ = {isa = PBXBuildFile; fileRef = 6549D674C4BBFC4AE9F553D4ABED4F95 /* MTLReflection.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
-		DEB5BA4CC6D4E8B4A618206E8081F9CD /* NSError+MTLModelException.m in Sources */ = {isa = PBXBuildFile; fileRef = A3B3600563469E165A512779D2952B19 /* NSError+MTLModelException.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		DF26D63341C55884A5ECB643D272B330 /* Pods-SnapchatKit_Tests-Mantle-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = FEC4C213ED5CC2EB2BD905D67424B9CE /* Pods-SnapchatKit_Tests-Mantle-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DF398EF5859B9F5086C1BE51410C5700 /* SKClient+Account.m in Sources */ = {isa = PBXBuildFile; fileRef = 20F34E602ECE0E9952C0C9CC8D2E971A /* SKClient+Account.m */; };
 		DF81798C84C2D3E1DF580686635F9669 /* SKUserStory.h in Headers */ = {isa = PBXBuildFile; fileRef = C24C62067E53B9DD2EB633790E6EECEA /* SKUserStory.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DFEB980E4F4E57C5FEB401FB969406FC /* SKNewConversation.m in Sources */ = {isa = PBXBuildFile; fileRef = E6543108894562824171DF82C827C732 /* SKNewConversation.m */; };
-		E000175AD5BB793F4139692885D2E352 /* MTLTransformerErrorHandling.m in Sources */ = {isa = PBXBuildFile; fileRef = B0B3A02E4506C7059D914FEF250427E1 /* MTLTransformerErrorHandling.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		E0101E016B646965B82683EE89D7A669 /* metamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 184E597AA48D3822ECF8AEB2135DD087 /* metamacros.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E05AECFEBB7267D2C971F2A83797EE85 /* NSString+SnapchatKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 54460D90C5A5A625598F1A72569A13B5 /* NSString+SnapchatKit.m */; };
 		E0EDEDBD0C23C8846BE28771D2A09854 /* NSDictionary+MTLJSONKeyPath.h in Headers */ = {isa = PBXBuildFile; fileRef = A3A065B43F6F4A3AB98235E4C41E9E6A /* NSDictionary+MTLJSONKeyPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E1AD65F6F30698D685A8D32632029724 /* NSError+MTLModelException.m in Sources */ = {isa = PBXBuildFile; fileRef = A3B3600563469E165A512779D2952B19 /* NSError+MTLModelException.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		E23D57BFB4769ABEF5C651093A1B5D64 /* UnknownFieldSet.m in Sources */ = {isa = PBXBuildFile; fileRef = E7FF2C7F1C9F03E9F9FFEEEB71828E5D /* UnknownFieldSet.m */; };
 		E24816B991E55EE80A0B76199812A802 /* mztools.h in Headers */ = {isa = PBXBuildFile; fileRef = 1685FA7977E1A72A8CA039CF99A88D23 /* mztools.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E430B9441FFAAB0E2B802FC6BFFAA438 /* SKFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 7548F1AD067B99B153C9CFDB0BC160DC /* SKFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E4B95563FE886803F236930DF455AC2F /* NSDictionary+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 523519361513D98C2F08E815B11DEF1B /* NSDictionary+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E5B04ED2F260F274813B97D4FC99E40C /* EXTScope.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D5F2EFE545E38C869A6A2D1EABEFE6F /* EXTScope.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		E5E105928FA9936BAE93F7876C13C6C5 /* Attestation.pb.h in Headers */ = {isa = PBXBuildFile; fileRef = C90F6DCB8E6D5E5AD3B2C839EDF984C8 /* Attestation.pb.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E6999BDF965B57D4A038B9CFFD76FA89 /* SKClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E0A9E84EC29594B57D6036A4B137EB0 /* SKClient.m */; };
 		E73B87CE570187A97236785B79B51AA9 /* SKClient+Chat.m in Sources */ = {isa = PBXBuildFile; fileRef = 23C622E56337996E2A8713254F5BD246 /* SKClient+Chat.m */; };
@@ -525,6 +525,7 @@
 		E94DA6BC5D83F8BF9762B3F908DFDB28 /* NSArray+MTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 06531AAEF120FF70E927F40F0A61C49D /* NSArray+MTLManipulationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EA421C49ED5CB42A1E100FFE23A6F128 /* SKNewConversation.m in Sources */ = {isa = PBXBuildFile; fileRef = E6543108894562824171DF82C827C732 /* SKNewConversation.m */; };
 		EA882E0938950C8981FDC2CD09D2E905 /* NSString+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 01D3D233D27189A14C4D48B64946BEDC /* NSString+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EAACDA51DE4D3529766B31AAC757B2CE /* MTLReflection.m in Sources */ = {isa = PBXBuildFile; fileRef = 6549D674C4BBFC4AE9F553D4ABED4F95 /* MTLReflection.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		EB65D934E0D62C636CE934DA5C9A7D04 /* SKClient+Friends.h in Headers */ = {isa = PBXBuildFile; fileRef = 833D0F7844FB6F9844FF13EF09871134 /* SKClient+Friends.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EBA05579591C2B62DABA4CEE0F877FD7 /* GeneratedMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = B3547AAE494746F0CF2277659F9390E4 /* GeneratedMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EC6E285E97BC2568438B6ECEA648AD17 /* SKSnap.m in Sources */ = {isa = PBXBuildFile; fileRef = 802057E388A43AE12453D12948E1951C /* SKSnap.m */; };
@@ -532,6 +533,7 @@
 		ED5C837809483B9C9AAA74610D4D4487 /* SKUserStory.m in Sources */ = {isa = PBXBuildFile; fileRef = EBF31098D1B73D4027EF54C1B7EC55E7 /* SKUserStory.m */; };
 		EEB188DDA5FA84A3833B10075DF8CD60 /* UnknownFieldSetBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = F4B5E1A7AAE7E607AC9E54D4FA333BAB /* UnknownFieldSetBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EEFD1F92F6CCEEA2C2C5803EAC2FF640 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46EF97B3320D5567B3CD996D681E6DB9 /* Foundation.framework */; };
+		EF6C74F413763743006A11A4D36961E0 /* MTLTransformerErrorHandling.m in Sources */ = {isa = PBXBuildFile; fileRef = B0B3A02E4506C7059D914FEF250427E1 /* MTLTransformerErrorHandling.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		EF806F7116EEA807CA2999CE29687C93 /* SKStory.m in Sources */ = {isa = PBXBuildFile; fileRef = 9269F78B7355A85A30F6036EEAAC51C9 /* SKStory.m */; };
 		F02AD884511F86B6072F31F21E65FD92 /* SKStoryNote.m in Sources */ = {isa = PBXBuildFile; fileRef = E7264B33B0A0713CE212280490FD1800 /* SKStoryNote.m */; };
 		F1001B8C74D414F6CDC31054A42C1111 /* Field.h in Headers */ = {isa = PBXBuildFile; fileRef = AEA4DB5D58231D27AC6CDE90D7240533 /* Field.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -539,10 +541,9 @@
 		F18511E4DF971F9AF0462EF1164F88E9 /* ioapi.h in Headers */ = {isa = PBXBuildFile; fileRef = B99D5FA99A6C1A06B1CC07FF55B44986 /* ioapi.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F1D71D1C89028248B09C70E609D53ECE /* SKSnapOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F8EFE9CDCA52EC0CCBD1DF32DA061F4 /* SKSnapOptions.m */; };
 		F2A1C19B2F3B275D87FCA549545ED92E /* unzip.c in Sources */ = {isa = PBXBuildFile; fileRef = E76B54A5B681A52C9BF1A48F75B3DE3F /* unzip.c */; };
-		F3306B4D0AD2368F1784A8B01FD7D161 /* MTLValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 30966F6B3985DE33FEB91E8D08220629 /* MTLValueTransformer.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		F3A05D289FC621F6A6C9F3E6CF1DBE8D /* SKAddedFriend.m in Sources */ = {isa = PBXBuildFile; fileRef = 168FBDE79E6B224781B59DDED990CC1D /* SKAddedFriend.m */; };
+		F3BD13063764DC2261DD490106AB7774 /* MTLJSONAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D6DA22E10B78E607B571F2A55C30EF9 /* MTLJSONAdapter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		F560CF8AE9C997FB694C90CFF64E5D14 /* SKSimpleUser.h in Headers */ = {isa = PBXBuildFile; fileRef = E54E26EDFAA3F10A36830DE50A7A5B14 /* SKSimpleUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F6C050F56A15ED6FCE70398A104B445D /* NSObject+MTLComparisonAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 452A825C1C9779653BE134C643213E98 /* NSObject+MTLComparisonAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		F79573CC859A0680C237044ADF482B40 /* GeneratedMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 7141EAD9F0391CA0B89AA690FD467035 /* GeneratedMessage.m */; };
 		F7B21C00A641625866299AE0F557B18C /* SKClient+Snaps.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B86B77A0AE12A3715630EF1051CE196 /* SKClient+Snaps.m */; };
 		F8FDA8D22AC9594294EB4F2E6FBC001A /* SKClient+Discover.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B6CEADD2D0C33311B5DF1F367E954A5 /* SKClient+Discover.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -561,7 +562,6 @@
 		FDEA050FD7978641030E57BEFE8FA338 /* Utilities.m in Sources */ = {isa = PBXBuildFile; fileRef = E059AC38BADB0D1B36F1843E1BE50C2F /* Utilities.m */; };
 		FED1C4AF2195F2A79F78E6A21E51C79B /* SKClient+Discover.m in Sources */ = {isa = PBXBuildFile; fileRef = 3483A1EC7B5CF9FAD309261F6519CDF3 /* SKClient+Discover.m */; };
 		FEDC22E4B5A3BF58B772CEA1463515FB /* Pods-SnapchatKit_Example-SnapchatKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D6CD685B05060FD7B7E01EF0D9851D1E /* Pods-SnapchatKit_Example-SnapchatKit-dummy.m */; };
-		FF789B5916DAE6C0D30932C9F259E3B8 /* MTLReflection.m in Sources */ = {isa = PBXBuildFile; fileRef = 6549D674C4BBFC4AE9F553D4ABED4F95 /* MTLReflection.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
 		FFE4568A31AC84530AFAE54120EE6EE9 /* SSZipArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = 864E8CC81A76CA838F6299352A05BC9D /* SSZipArchive.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
@@ -2060,22 +2060,22 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1B076DF3B4692E545CA4410C3A0B9E70 /* EXTRuntimeExtensions.m in Sources */,
-				BD4E59EDF409CBFD9D9728ACF6AA5881 /* EXTScope.m in Sources */,
-				6BA8B54DDCA21FFF73BD889120B17A56 /* MTLJSONAdapter.m in Sources */,
-				46204E30E187CD54D9E99E2FAA750AE0 /* MTLModel+NSCoding.m in Sources */,
-				6FC9297284E6B97475C34E5F64955D1B /* MTLModel.m in Sources */,
-				FF789B5916DAE6C0D30932C9F259E3B8 /* MTLReflection.m in Sources */,
-				49F1F759E3211F99AE1EB258A0539A3E /* MTLTransformerErrorHandling.m in Sources */,
-				D209D6CC69F6B7EBEDBB9B94FC2B1553 /* MTLValueTransformer.m in Sources */,
-				6CD5886E1C8F03E20962E8E3CBFFFD46 /* NSArray+MTLManipulationAdditions.m in Sources */,
-				CE05F613D4B6C6F6F13C5237ED8DD23F /* NSDictionary+MTLJSONKeyPath.m in Sources */,
-				8658349B9E14201EDFD7D4697801AB42 /* NSDictionary+MTLManipulationAdditions.m in Sources */,
-				7CDB177F22682CBFA481206CADF09D37 /* NSDictionary+MTLMappingAdditions.m in Sources */,
-				79A99170C7433CE688B43AC977697B2C /* NSError+MTLModelException.m in Sources */,
-				F6C050F56A15ED6FCE70398A104B445D /* NSObject+MTLComparisonAdditions.m in Sources */,
-				23909EA74D814415AD25CAA0D3429E8A /* NSValueTransformer+MTLInversionAdditions.m in Sources */,
-				9A99F08C293A16C31870858C276DFD94 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */,
+				9013316F80ACF1D91D90B340AB16D7EA /* EXTRuntimeExtensions.m in Sources */,
+				1A396CAA57FAFE6CB901C87A93904F21 /* EXTScope.m in Sources */,
+				F3BD13063764DC2261DD490106AB7774 /* MTLJSONAdapter.m in Sources */,
+				906785162BA8A0D06C02C4EEF497F3AB /* MTLModel+NSCoding.m in Sources */,
+				CFDC763E5EEB85D70D2ECF4145F5193E /* MTLModel.m in Sources */,
+				C48D966383CB72397DFCE90FC2169A44 /* MTLReflection.m in Sources */,
+				EF6C74F413763743006A11A4D36961E0 /* MTLTransformerErrorHandling.m in Sources */,
+				65DA0ECAF7EBF7CBD51756BC66566B9B /* MTLValueTransformer.m in Sources */,
+				6408239CE05D0CBC8D45E28E3CCF95F3 /* NSArray+MTLManipulationAdditions.m in Sources */,
+				0C30C90656ECBECF298AD0160715EA48 /* NSDictionary+MTLJSONKeyPath.m in Sources */,
+				6A46FDF31F2E0E67ED93E71F670DFDBA /* NSDictionary+MTLManipulationAdditions.m in Sources */,
+				052AE2FC96F5F2FA1BED86D111E0F4F0 /* NSDictionary+MTLMappingAdditions.m in Sources */,
+				68A2BB69EEF9DCFE5A66D45C2C3E5839 /* NSError+MTLModelException.m in Sources */,
+				488F2949058090EC2188C8E5FA79D184 /* NSObject+MTLComparisonAdditions.m in Sources */,
+				0FDD7201F16809B2433B7543FC6CC530 /* NSValueTransformer+MTLInversionAdditions.m in Sources */,
+				AF6C8CFE2A8CC031E4F875E0D65B0505 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */,
 				A6CD5AF026F0476BFA019BA291B70CA1 /* Pods-SnapchatKit_Tests-Mantle-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2092,22 +2092,22 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B28D218A54569D6D4E6242C19557860F /* EXTRuntimeExtensions.m in Sources */,
-				0BB90E81EBAD7A3CC465A757B8380910 /* EXTScope.m in Sources */,
-				26011E3D61F619D4A9BCEC383FEAC05D /* MTLJSONAdapter.m in Sources */,
-				516823A4FA02BBC792E37395AD1B85DB /* MTLModel+NSCoding.m in Sources */,
-				7D91CF1B01A4BE4B453227A680729D21 /* MTLModel.m in Sources */,
-				DEA5708CAC1F0A0CB8A7F6BD2F04CC7C /* MTLReflection.m in Sources */,
-				E000175AD5BB793F4139692885D2E352 /* MTLTransformerErrorHandling.m in Sources */,
-				F3306B4D0AD2368F1784A8B01FD7D161 /* MTLValueTransformer.m in Sources */,
-				500930FB6D697F545409818C0A93179B /* NSArray+MTLManipulationAdditions.m in Sources */,
-				713AE4F662C0ABD9A6AB9CCA7E789BC9 /* NSDictionary+MTLJSONKeyPath.m in Sources */,
-				3D5C7C244711B6322687777E61E19A6C /* NSDictionary+MTLManipulationAdditions.m in Sources */,
-				77EC3AD9A16F93D2A99FA7E24077B4C2 /* NSDictionary+MTLMappingAdditions.m in Sources */,
-				DEB5BA4CC6D4E8B4A618206E8081F9CD /* NSError+MTLModelException.m in Sources */,
-				DA2AB6464AEFC1DBE969E84F5836188F /* NSObject+MTLComparisonAdditions.m in Sources */,
-				82D808B2D325BA2A254E565C8F6CC555 /* NSValueTransformer+MTLInversionAdditions.m in Sources */,
-				80C63601371D20829F892DC9CA8CC421 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */,
+				8C256964C1A9CAB8514584772DD9A9EB /* EXTRuntimeExtensions.m in Sources */,
+				E5B04ED2F260F274813B97D4FC99E40C /* EXTScope.m in Sources */,
+				0999E6A9C74BDA82BCD8B7CFB54AE488 /* MTLJSONAdapter.m in Sources */,
+				BFB50EB3EDD355B13E36D6DFAAABFC07 /* MTLModel+NSCoding.m in Sources */,
+				3850E499957400FD1BAC9A0109F5EE52 /* MTLModel.m in Sources */,
+				EAACDA51DE4D3529766B31AAC757B2CE /* MTLReflection.m in Sources */,
+				CFCED157CD10D394DB19A3A73845D397 /* MTLTransformerErrorHandling.m in Sources */,
+				27D62862900D1134988F4606B032AA44 /* MTLValueTransformer.m in Sources */,
+				90B289988B70AE68D7A33F72FF79E7D4 /* NSArray+MTLManipulationAdditions.m in Sources */,
+				A7579F506B62E5A6FC1AD11F61843AB5 /* NSDictionary+MTLJSONKeyPath.m in Sources */,
+				3165B0D846A156E1ACBF659BAA4E9F12 /* NSDictionary+MTLManipulationAdditions.m in Sources */,
+				67850AD9F804B9C25549DBC296068694 /* NSDictionary+MTLMappingAdditions.m in Sources */,
+				E1AD65F6F30698D685A8D32632029724 /* NSError+MTLModelException.m in Sources */,
+				828CDEC7DFB75BD78C84DB785597E016 /* NSObject+MTLComparisonAdditions.m in Sources */,
+				5B896FA68AEE9209B02BD5A1A58ED398 /* NSValueTransformer+MTLInversionAdditions.m in Sources */,
+				016DCC45D6DA2C1272C0E6B1ADE05A1C /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */,
 				BF596A9358398FD70766E2748274387F /* Pods-SnapchatKit_Example-Mantle-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2455,6 +2455,36 @@
 			};
 			name = Debug;
 		};
+		3295EB533A495C6354F23EF22CDD50A6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 71A8832A82F9F7AA9EB8BFCDD2C5BEB7 /* Pods-SnapchatKit_Example.debug.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit_Example/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Example/Pods-SnapchatKit_Example.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = Pods_SnapchatKit_Example;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
 		485BAD33A8498D558CAE6C895C23B045 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 33BC1AF5B43B9D9D4E7129B4BC704208 /* Pods-SnapchatKit-OSX-Mantle.xcconfig */;
@@ -2483,7 +2513,34 @@
 			};
 			name = Release;
 		};
-		567B8A20A3F29EC90776453F36F1FB1E /* Release */ = {
+		5A99A64785A8E35F4E7329EA752D545C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B93970AA91389B580BA81FA9119ABEB4 /* Pods-SnapchatKit_Example-Mantle.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-SnapchatKit_Example-Mantle/Pods-SnapchatKit_Example-Mantle-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit_Example-Mantle/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Example-Mantle/Pods-SnapchatKit_Example-Mantle.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = Mantle;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		6CC51F32A70AD31BF8DA3E076A601537 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = B313D16EBCED2CE282F1548F5502B190 /* Pods-SnapchatKit_Example.release.xcconfig */;
 			buildSettings = {
@@ -2496,7 +2553,7 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit_Example/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACH_O_TYPE = staticlib;
 				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Example/Pods-SnapchatKit_Example.modulemap";
@@ -2505,33 +2562,6 @@
 				OTHER_LIBTOOLFLAGS = "";
 				PODS_ROOT = "$(SRCROOT)";
 				PRODUCT_NAME = Pods_SnapchatKit_Example;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		5EDBD32C39E404A44393E1D1F29485D0 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 72F3609C47429493997503C14DD74194 /* Pods-SnapchatKit_Example-SnapchatKit.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-SnapchatKit_Example-SnapchatKit/Pods-SnapchatKit_Example-SnapchatKit-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit_Example-SnapchatKit/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Example-SnapchatKit/Pods-SnapchatKit_Example-SnapchatKit.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = SnapchatKit;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -2575,36 +2605,6 @@
 			};
 			name = Release;
 		};
-		727BB0F812E2A5908B2BCD3187F03C42 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 71A8832A82F9F7AA9EB8BFCDD2C5BEB7 /* Pods-SnapchatKit_Example.debug.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit_Example/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Example/Pods-SnapchatKit_Example.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = Pods_SnapchatKit_Example;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
 		80C632F58EE202C42BB47E91FB960338 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2644,33 +2644,6 @@
 				SYMROOT = "${SRCROOT}/../build";
 			};
 			name = Debug;
-		};
-		837EDE2EF65FBA86E21FC93A612EE69B /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = B93970AA91389B580BA81FA9119ABEB4 /* Pods-SnapchatKit_Example-Mantle.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-SnapchatKit_Example-Mantle/Pods-SnapchatKit_Example-Mantle-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit_Example-Mantle/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Example-Mantle/Pods-SnapchatKit_Example-Mantle.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = Mantle;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
 		};
 		859232D9EAAF07288BE565F406937B5C /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -2784,6 +2757,60 @@
 			};
 			name = Debug;
 		};
+		9F8B2951D57975E1CF41EB362104EFEE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 72F3609C47429493997503C14DD74194 /* Pods-SnapchatKit_Example-SnapchatKit.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-SnapchatKit_Example-SnapchatKit/Pods-SnapchatKit_Example-SnapchatKit-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit_Example-SnapchatKit/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Example-SnapchatKit/Pods-SnapchatKit_Example-SnapchatKit.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = SnapchatKit;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		B3CF75ED9659B1EBB253C0A58A31B287 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B93970AA91389B580BA81FA9119ABEB4 /* Pods-SnapchatKit_Example-Mantle.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-SnapchatKit_Example-Mantle/Pods-SnapchatKit_Example-Mantle-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit_Example-Mantle/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Example-Mantle/Pods-SnapchatKit_Example-Mantle.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = Mantle;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 		B6B77653AE6B7EF5ABD9DEF9E301354F /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = CDEAC9BF0BF4585523A58300F58B3CDD /* Pods-SnapchatKit-OSX.release.xcconfig */;
@@ -2810,6 +2837,33 @@
 				PRODUCT_NAME = Pods_SnapchatKit_OSX;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		BED5AD0BB5F9829B064CDDD3B17F7615 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 72F3609C47429493997503C14DD74194 /* Pods-SnapchatKit_Example-SnapchatKit.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-SnapchatKit_Example-SnapchatKit/Pods-SnapchatKit_Example-SnapchatKit-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit_Example-SnapchatKit/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Example-SnapchatKit/Pods-SnapchatKit_Example-SnapchatKit.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = SnapchatKit;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -2872,60 +2926,6 @@
 			};
 			name = Debug;
 		};
-		F869333BC6956F9C2386276A29C883EA /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 72F3609C47429493997503C14DD74194 /* Pods-SnapchatKit_Example-SnapchatKit.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-SnapchatKit_Example-SnapchatKit/Pods-SnapchatKit_Example-SnapchatKit-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit_Example-SnapchatKit/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Example-SnapchatKit/Pods-SnapchatKit_Example-SnapchatKit.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = SnapchatKit;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		FFECA6D0622709252CD61CF518DC205E /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = B93970AA91389B580BA81FA9119ABEB4 /* Pods-SnapchatKit_Example-Mantle.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-SnapchatKit_Example-Mantle/Pods-SnapchatKit_Example-Mantle-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit_Example-Mantle/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Example-Mantle/Pods-SnapchatKit_Example-Mantle.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = Mantle;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -2968,8 +2968,8 @@
 		BA976E4281AA96A08B4D886E8071851E /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit_Example-Mantle" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				FFECA6D0622709252CD61CF518DC205E /* Debug */,
-				837EDE2EF65FBA86E21FC93A612EE69B /* Release */,
+				5A99A64785A8E35F4E7329EA752D545C /* Debug */,
+				B3CF75ED9659B1EBB253C0A58A31B287 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -2986,8 +2986,8 @@
 		C803C9F374D309829EB1D032F4E421EF /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit_Example-SnapchatKit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				F869333BC6956F9C2386276A29C883EA /* Debug */,
-				5EDBD32C39E404A44393E1D1F29485D0 /* Release */,
+				9F8B2951D57975E1CF41EB362104EFEE /* Debug */,
+				BED5AD0BB5F9829B064CDDD3B17F7615 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -3013,8 +3013,8 @@
 		F5B8BA0FAB64774C83EE04CA36042ACF /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit_Example" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				727BB0F812E2A5908B2BCD3187F03C42 /* Debug */,
-				567B8A20A3F29EC90776453F36F1FB1E /* Release */,
+				3295EB533A495C6354F23EF22CDD50A6 /* Debug */,
+				6CC51F32A70AD31BF8DA3E076A601537 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,1897 +7,1849 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		004FA0B529046958F4B620DB /* EXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 515761136CC4D2DA31CBDCCE /* EXTRuntimeExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		00F407C5EB2EA7F955BCEABF /* ProtocolBuffers.h in Headers */ = {isa = PBXBuildFile; fileRef = 60CD411A1CA63391B2D224AB /* ProtocolBuffers.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0194FA76F657F16C21C55A80 /* SKFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CC372A04E32E3B5A10B6683 /* SKFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0250B2604E1F7FDBAF4C8240 /* SKSnapResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 123AA38787CE03C6CCCD59EF /* SKSnapResponse.m */; };
-		02EE112E0E467E8DF3DF9791 /* Utilities.h in Headers */ = {isa = PBXBuildFile; fileRef = B758A255FCB12557BF687DBF /* Utilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0458D6DE15DAF5364E32A021 /* NSValueTransformer+MTLPredefinedTransformerAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = E85AA3FDA1B47E649DCA1DD1 /* NSValueTransformer+MTLPredefinedTransformerAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		04EAD7E1C58FB7C291AEF825 /* SKAddedFriend.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CB417E7FA3A2177453C0458 /* SKAddedFriend.m */; };
-		0545D625AA44EAFAC518F9BB /* SKClient+Device.h in Headers */ = {isa = PBXBuildFile; fileRef = F1DE6FC4BDB289A1735EC820 /* SKClient+Device.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		05750A109F18B9D4BE023394 /* MTLJSONAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = F275805645C8FED83BC58CE7 /* MTLJSONAdapter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		0592B5F45B102056FEBFFCA9 /* GeneratedMessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 116CA5F3E415255E8D2A4C6B /* GeneratedMessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		059BB8BF576C6A543361734B /* MTLTransformerErrorHandling.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E2EF527D485AA3518965377 /* MTLTransformerErrorHandling.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		05B79CCD118252452F844B53 /* NSDictionary+MTLMappingAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = B74CCA0F13F010EF6C5F3108 /* NSDictionary+MTLMappingAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		087F54586B12E13AA1E5F905 /* SKBlob.m in Sources */ = {isa = PBXBuildFile; fileRef = C72DBD7A6DA7655074E62D29 /* SKBlob.m */; };
-		08A4B40F522CD26BC5C0F844 /* NSValueTransformer+MTLInversionAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 79892EA1B4AA29856078EE35 /* NSValueTransformer+MTLInversionAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		08D982B6DEE9D8A8DD91A605 /* AbstractMessageBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 35EF0345D98539E68C6DCCF0 /* AbstractMessageBuilder.m */; };
-		09279759F91D12E069867969 /* SKNearbyUser.m in Sources */ = {isa = PBXBuildFile; fileRef = DC77D677392F90E40D0F2B2F /* SKNearbyUser.m */; };
-		09EB6F305CEC6C8B45BE8127 /* NSDictionary+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A09000891FE155F04E84237 /* NSDictionary+MTLManipulationAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		0A641B5357EEB3E90D3A235B /* SKClient+Friends.h in Headers */ = {isa = PBXBuildFile; fileRef = CD7CF6D3EDE14721A9FA183B /* SKClient+Friends.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0B3BD1EECDE7DE487A36CAE9 /* SKUser.h in Headers */ = {isa = PBXBuildFile; fileRef = 5ED60ED9A8DEB4AF13B67CC8 /* SKUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0B7A864E3694EF1ED0FB53B0 /* SKClient+Chat.m in Sources */ = {isa = PBXBuildFile; fileRef = 31201F9C36DCB8072A773375 /* SKClient+Chat.m */; };
-		0CA87602D1EB72F9A1416C65 /* SKStoryUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = F2DB5DC9CB68ABDBF1C8F8AE /* SKStoryUpdater.m */; };
-		0CE07962AB69F5793566C06A /* Descriptor.pb.h in Headers */ = {isa = PBXBuildFile; fileRef = B5F8AE9D9CC92F9D2639DE69 /* Descriptor.pb.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0E4D5D23AF5E9CAF2EC702DD /* Pods-SnapchatKit-OSX-Mantle-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D31FC75657D73CC0298E1EF /* Pods-SnapchatKit-OSX-Mantle-dummy.m */; };
-		0E673034C1E0945C60D674D9 /* SKConversation.m in Sources */ = {isa = PBXBuildFile; fileRef = 701146DB20AFF386866AA783 /* SKConversation.m */; };
-		0ED972130FBE078D5B9CF594 /* SKLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BD6662AFDE6D73BB17E57D0 /* SKLocation.m */; };
-		0F3E66D7D81AC8F0BFC8B580 /* CodedOutputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F89D17AA09083FFEC8C72CF /* CodedOutputStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0F4B0F855BFBF02074C35C69 /* SKStory.h in Headers */ = {isa = PBXBuildFile; fileRef = 76CC3491B3E0E22C56D21730 /* SKStory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0FC2A55B7B4F53C7E234CEAD /* SKClient+Stories.h in Headers */ = {isa = PBXBuildFile; fileRef = 0352130AD3816023F8068ECA /* SKClient+Stories.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0FF4A7B67045536EE656FA60 /* SKLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CE06043D4DC81317EE540DE /* SKLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0FFDA0ABCDC7D78ABA284CFF /* EXTKeyPathCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = A9FBC3803D641A8AF3A1A033 /* EXTKeyPathCoding.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		100B3EF160D7A5552DAB0784 /* NSArray+SnapchatKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 4693BF7FBC62DA24F8CB6153 /* NSArray+SnapchatKit.m */; };
-		1011AB44146881FD98818A56 /* SKSimpleUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 022825FCF2BAF08416579518 /* SKSimpleUser.m */; };
-		107C758D74525A4BACC126C7 /* PBArray.m in Sources */ = {isa = PBXBuildFile; fileRef = D14F237EC025DFF27B83C274 /* PBArray.m */; };
-		10B746F3D906A087DF30A582 /* SKClient+Stories.h in Headers */ = {isa = PBXBuildFile; fileRef = 0352130AD3816023F8068ECA /* SKClient+Stories.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		10BFC08096EED3AFBE874BFF /* MTLReflection.h in Headers */ = {isa = PBXBuildFile; fileRef = 9EBA09F0C92556545D654BDD /* MTLReflection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		110E1194B010D41AF45D294A /* MTLJSONAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = F275805645C8FED83BC58CE7 /* MTLJSONAdapter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		11EB7D51AFD16587C94D84E2 /* SKSimpleUser.h in Headers */ = {isa = PBXBuildFile; fileRef = BFA49567896C833E44B3C4A1 /* SKSimpleUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1239BC592573C7195BFF9EA0 /* RingBuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D12E82F0CEA77B8F7DE1F9B /* RingBuffer.m */; };
-		1272BDE2A1CB62E9B4FB21C9 /* MTLReflection.h in Headers */ = {isa = PBXBuildFile; fileRef = 9EBA09F0C92556545D654BDD /* MTLReflection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		12AB2A8AE1D927851B2F98F6 /* NSValueTransformer+MTLPredefinedTransformerAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = E85AA3FDA1B47E649DCA1DD1 /* NSValueTransformer+MTLPredefinedTransformerAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1413663A4CB8D03E1B821481 /* NSString+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B208DD3ECC3E9C53BF230B7 /* NSString+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		14C746FCBFB13DE7BED2CFD1 /* SKSimpleUser.h in Headers */ = {isa = PBXBuildFile; fileRef = BFA49567896C833E44B3C4A1 /* SKSimpleUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		152AABCD098E7C2CF54A5E52 /* NSObject+MTLComparisonAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = E3F90C74F6B4513DB6B80D92 /* NSObject+MTLComparisonAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		15631C36FA1E1C7CB370C69F /* SKClient+Snaps.h in Headers */ = {isa = PBXBuildFile; fileRef = E4DD12BC1374B1D0F8A542E6 /* SKClient+Snaps.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1586153C17E4F6008A17397D /* MTLReflection.m in Sources */ = {isa = PBXBuildFile; fileRef = B0A48052AEB65F7B647DB473 /* MTLReflection.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		15B2F048F78324F41404B86B /* SKClient+Stories.m in Sources */ = {isa = PBXBuildFile; fileRef = 17D0AA7AA0EA6CC242B330F9 /* SKClient+Stories.m */; };
-		16F5989EEE19D8B976BCD2D4 /* NSDictionary+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A09000891FE155F04E84237 /* NSDictionary+MTLManipulationAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		172C229739F21656C12499C0 /* ExtensionRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 679719A8EC9FC6E3B23D6151 /* ExtensionRegistry.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1854CCB2C5C2D6ACFF7496EE /* SKStoryUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = AD9CE5C7E8B71B7A717BF7CF /* SKStoryUpdater.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1855834EC91DA3FD0D59657F /* ConcreteExtensionField.m in Sources */ = {isa = PBXBuildFile; fileRef = 7604B3135534C28027647CD5 /* ConcreteExtensionField.m */; };
-		18A3D5CBDDF4B83AE292D1C3 /* mztools.h in Headers */ = {isa = PBXBuildFile; fileRef = 6D9B66EB6E20F1C7D4AD8AA0 /* mztools.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		18C01EC3370D069753316496 /* AbstractMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F32C4F587D89334A3BCBE23 /* AbstractMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1949E7BEB3C4CB4E5FAE92D2 /* NSDictionary+MTLJSONKeyPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 864BFCBBD456ACC6691691E9 /* NSDictionary+MTLJSONKeyPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		19E14AD871D0C43BAB0E101F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01A3D282D76F2492158972A9 /* Foundation.framework */; };
-		1A32E594FF1F5FDDF20566F9 /* Descriptor.pb.h in Headers */ = {isa = PBXBuildFile; fileRef = B5F8AE9D9CC92F9D2639DE69 /* Descriptor.pb.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1A5AFE6A8B2FEE7288DEED60 /* ExtensionRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 1628AB0CEF6EECD372AA222B /* ExtensionRegistry.m */; };
-		1AFCC2894C7B42B619C7335B /* SSZipArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = 9580C868D4BD628B16033847 /* SSZipArchive.m */; };
-		1B4B45662A9E71621EE49246 /* MTLModel+NSCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B58BC08B10D15123B320AFD /* MTLModel+NSCoding.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		1BEE0A4B7B923E1F21A48FFA /* SKAddedFriend.h in Headers */ = {isa = PBXBuildFile; fileRef = A766840A3FA15875DD115B84 /* SKAddedFriend.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1CA82CF9525D04A7195D475B /* TextFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = 502600138FD1162EC5F0E835 /* TextFormat.m */; };
-		1CCB2AD4ADCA9CCD36AED267 /* SKMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = EB8FB810CD3E9AF9303846D2 /* SKMessage.m */; };
-		1D6D709CAAD55DA400ED60D5 /* ExtensionRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 679719A8EC9FC6E3B23D6151 /* ExtensionRegistry.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1E29F150246CEDA360EB6F39 /* Mantle.h in Headers */ = {isa = PBXBuildFile; fileRef = E143F32D6FBEF9E2E0AD119E /* Mantle.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1E3D15AF006295CEB3060ACB /* SKStoryCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = B475512FAECA1EDC22AF0197 /* SKStoryCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1F490674EE81DEF6CCB6EF05 /* SKNewConversation.m in Sources */ = {isa = PBXBuildFile; fileRef = 150E0D42F8ADD64688F5FF77 /* SKNewConversation.m */; };
-		201F619DB350D8E0E6A26519 /* NSString+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B208DD3ECC3E9C53BF230B7 /* NSString+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2075D5A637A1ED065D56794E /* SKMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7029FB4531206FAF1E971E /* SKMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		218054F9F32F7A64D36ED36C /* EXTScope.m in Sources */ = {isa = PBXBuildFile; fileRef = 74DF1D6CA9D178F9CEE62E29 /* EXTScope.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		21B5C4BFE4DEB877BA691ECE /* RingBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = AA149B4D211D5124D4002334 /* RingBuffer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		227E068AC23CD9EC5B781563 /* zip.h in Headers */ = {isa = PBXBuildFile; fileRef = 36535381D153E491915E5B96 /* zip.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		22A5A04035FDBFFE356DA500 /* EXTScope.m in Sources */ = {isa = PBXBuildFile; fileRef = 74DF1D6CA9D178F9CEE62E29 /* EXTScope.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		232BB9949D014806CE6A1FF2 /* UnknownFieldSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A2AAA454116F315A4C5A440 /* UnknownFieldSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2350F671A248F17D4A961069 /* SKNewConversation.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FFFD75623FB9218D73DE323 /* SKNewConversation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		246FD8ECEC071DB6BDE05A2E /* SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = D3CB8B66AC28E9296B200E45 /* SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		248C7DBA50825196E1BAAE4A /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = C90C099E43248D72169A5B0B /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		24AC4CC0E5A1B56812826111 /* SKStory.h in Headers */ = {isa = PBXBuildFile; fileRef = 76CC3491B3E0E22C56D21730 /* SKStory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		24AC952DB486CBA15DF70A7B /* MTLValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8EE2DC94841F1D57870388D7 /* MTLValueTransformer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		252744BFB664C6961DB01E2D /* zip.c in Sources */ = {isa = PBXBuildFile; fileRef = EB9C7549B766712AC0F5F9F7 /* zip.c */; };
-		252ACE2C909E7A359525294E /* MutableExtensionRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DC7CD3FB2E0D2C3AF55E726 /* MutableExtensionRegistry.m */; };
-		25E27AC84E658489E3E544CF /* NSArray+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 5458179AFBA3B4551E76D06C /* NSArray+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		26B312C47B6AEDCD92C66328 /* ProtocolBuffers.h in Headers */ = {isa = PBXBuildFile; fileRef = 60CD411A1CA63391B2D224AB /* ProtocolBuffers.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		27192CE744756B9B2A0F2CC5 /* SKFoundFriend.m in Sources */ = {isa = PBXBuildFile; fileRef = B71A42ED9C9A282E7A4B4542 /* SKFoundFriend.m */; };
-		274DE44536EC4079EBA66122 /* GeneratedMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = F6310B7A8D4CCC215C36FC42 /* GeneratedMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		27A2EC96D041834ABAD11051 /* SKClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E47188605DEAD31B32CA84A /* SKClient.m */; };
-		27EB1C393CAD9F67B16FE188 /* SKClient+Snaps.m in Sources */ = {isa = PBXBuildFile; fileRef = C59B176424A659FA44EB301D /* SKClient+Snaps.m */; };
-		28B73A25E281BCA1914A2BC3 /* CodedInputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 29CFD017511A61FDEEFEF7FB /* CodedInputStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		28DE9E6986291322987F2C5D /* Pods-SnapchatKit_Example-SnapchatKit-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 7429D3F53C745B01ABB0BD0A /* Pods-SnapchatKit_Example-SnapchatKit-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		29053A605C057F4849362B88 /* Descriptor.pb.m in Sources */ = {isa = PBXBuildFile; fileRef = 53358FC1AF684CCB6202172F /* Descriptor.pb.m */; };
-		294C993A8A0D629589C4DFE6 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6CCF63F998DDD570BF396F60 /* Foundation.framework */; };
-		29BC621D79114AB88D4F3786 /* SKSharedStoryDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 8FD3C16495412F844A298EA3 /* SKSharedStoryDescription.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		29D3BA19FAC789BE04FFC46C /* SKSimpleUser.h in Headers */ = {isa = PBXBuildFile; fileRef = BFA49567896C833E44B3C4A1 /* SKSimpleUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2A37F33512217C3FFE1A7E5B /* SKClient+Account.h in Headers */ = {isa = PBXBuildFile; fileRef = 468545A3D0F59F8EB5EC8623 /* SKClient+Account.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2A75997295BAB555CD2CB3C4 /* MTLModel+NSCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = C49BF5D2D648742FCBBC6433 /* MTLModel+NSCoding.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2AB080BD99FDBE080BED2313 /* SSZipArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = 5846DBD972BB2E4E8516487A /* SSZipArchive.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2ADF256D23028F49F768DB30 /* Utilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 11064E9E55CF944B7E747575 /* Utilities.m */; };
-		2AED1FE5BA84BE1B43A5CFAB /* MutableExtensionRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DC7CD3FB2E0D2C3AF55E726 /* MutableExtensionRegistry.m */; };
-		2BB26D0DBAB381AF0BA3C7CE /* WireFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 91FD8FDCB1EF8E5342243FB7 /* WireFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2C3473BFF27D0E6A0FC82815 /* SKFoundFriend.h in Headers */ = {isa = PBXBuildFile; fileRef = 607499C80038757E311F8CA1 /* SKFoundFriend.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2C45FD09CE17617116B38B51 /* SKRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 87DC6A533A3CB69CFE3FC6D8 /* SKRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2C48640BA70E63DC3DE49DDF /* SKThing.m in Sources */ = {isa = PBXBuildFile; fileRef = 480232BB439E70191B69829A /* SKThing.m */; };
-		2C72A82053A41B106C39D5BB /* NSData+SnapchatKit.m in Sources */ = {isa = PBXBuildFile; fileRef = DA7D052FF7B5D4F9FAB6264F /* NSData+SnapchatKit.m */; };
-		2CA233C22E3403EE6D35E894 /* crypt.h in Headers */ = {isa = PBXBuildFile; fileRef = 34BDFDCAB53D1C3DF3D8B643 /* crypt.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2CA436F80E98F4B93F06DA25 /* NSDictionary+SnapchatKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 1EDA4E519FE1136F8E6159C2 /* NSDictionary+SnapchatKit.m */; };
-		2CB298399D44BBC00DD7D822 /* SKFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = B3034C9C4729EFDDAF24276C /* SKFilter.m */; };
-		2CBF903CBF1B97B9B944E63F /* MTLValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8EE2DC94841F1D57870388D7 /* MTLValueTransformer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2CF97C8E17DB0D3EAA52A837 /* SKClient+Discover.h in Headers */ = {isa = PBXBuildFile; fileRef = FCA6532B428B695F70814807 /* SKClient+Discover.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2D0A8DC1B8D91599941BF9D5 /* NSDictionary+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7CA746CADA1BDA8DFD79E9 /* NSDictionary+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2D3458EE143931D9043E8D34 /* SKSnapResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = F128C2CF8C3AF119EF791658 /* SKSnapResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2D9D2359C9FD4C1D616365E4 /* UnknownFieldSet.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DD52DE4A9AAD6E3A69EB894 /* UnknownFieldSet.m */; };
-		2E6B51F40F8277E9FB5ED8C1 /* MTLTransformerErrorHandling.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F3BDE1CAA9A717200841609 /* MTLTransformerErrorHandling.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		2F6250796AABF930BB921FA0 /* SKStoryNote.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CC5CD60538DCDD4998B4E9D /* SKStoryNote.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2FD2E6238E459614CF6BA1F3 /* SKBlob.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A08CC8E2AC99F2D225D628E /* SKBlob.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		310C530E828EDCACBAA01DD1 /* MTLModel+NSCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B58BC08B10D15123B320AFD /* MTLModel+NSCoding.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		319FFF488A52A043E6F9A50C /* GeneratedMessageBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = A22019B34FF3D28330B16DF5 /* GeneratedMessageBuilder.m */; };
-		322438144786F9D0B1136756 /* Pods-SnapchatKit-OSX-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 73C1CB4E2FE3CF7FA2BAC175 /* Pods-SnapchatKit-OSX-dummy.m */; };
-		3248725B93BF6B53EB590A4F /* MutableField.h in Headers */ = {isa = PBXBuildFile; fileRef = B359AC7608C8680235607B64 /* MutableField.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		32BC4BEE03A1D47F515B3FB3 /* PBArray.m in Sources */ = {isa = PBXBuildFile; fileRef = D14F237EC025DFF27B83C274 /* PBArray.m */; };
-		32D0B7375CA3A39551088E4E /* SKClient.h in Headers */ = {isa = PBXBuildFile; fileRef = AD3C9AC8DBADBCAB8DA86DA8 /* SKClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		32EBBE6F5A33C2C5BB5AA27B /* SKNearbyUser.m in Sources */ = {isa = PBXBuildFile; fileRef = DC77D677392F90E40D0F2B2F /* SKNearbyUser.m */; };
-		33C54E7319A14672DC515B77 /* NSData+SnapchatKit.m in Sources */ = {isa = PBXBuildFile; fileRef = DA7D052FF7B5D4F9FAB6264F /* NSData+SnapchatKit.m */; };
-		33D38026929EF2F520145538 /* NSDictionary+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7CA746CADA1BDA8DFD79E9 /* NSDictionary+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		33DE13ABA5BB06C7DC73BD88 /* MTLModel.h in Headers */ = {isa = PBXBuildFile; fileRef = FF09072CAEC86883CBD1C5B7 /* MTLModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		341B108E22DBB2BAEC477BDB /* SKSession.h in Headers */ = {isa = PBXBuildFile; fileRef = 8ADC4AAB6A6ABCE48BCC5F84 /* SKSession.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3501CBCB3A0DF45E357D9D50 /* AbstractMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = C55205D98ACA2596E3A93000 /* AbstractMessage.m */; };
-		36A8BE1A04E94EAE99F9A21E /* GeneratedMessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 116CA5F3E415255E8D2A4C6B /* GeneratedMessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3789A77349BB65922E5A1AAB /* MTLValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7403F5AB3E4BE3F53F76912D /* MTLValueTransformer.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		37A160E0567E6599C2185A43 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01A3D282D76F2492158972A9 /* Foundation.framework */; };
-		37B19B76DF5EE1635FE3FF52 /* ExtendableMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 81D3C8E6CF0E4B9EC98608DF /* ExtendableMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3970F072825457A518B06022 /* SKNearbyUser.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C7595A2095D32ABE35F10FE /* SKNearbyUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		398CC926F5BD25EBEE7AC536 /* NSString+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B208DD3ECC3E9C53BF230B7 /* NSString+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		39C9AF5FA6D05B16392FB5A8 /* AbstractMessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 40971082BAA72F1F1EDAF695 /* AbstractMessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3A0EF056E963FD2A3B34B2D7 /* TextFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = 502600138FD1162EC5F0E835 /* TextFormat.m */; };
-		3A6A28EF49EEAF01C8723023 /* NSValueTransformer+MTLInversionAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 79892EA1B4AA29856078EE35 /* NSValueTransformer+MTLInversionAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3A891214EBE7D990E5A81DBD /* SKStoryCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F6C4F7854C482C05E42ED2B /* SKStoryCollection.m */; };
-		3AA8BD8C5381018DF5EF91F7 /* SSZipArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = 5846DBD972BB2E4E8516487A /* SSZipArchive.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3AB879ED75750BAA20844DA3 /* SKSession.m in Sources */ = {isa = PBXBuildFile; fileRef = E258F52BF2199045E866A6F0 /* SKSession.m */; };
-		3ACE1C6E65F9E1EE2400ADA2 /* SKCashTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = EBAC7CF928D68AD3EE37FB4D /* SKCashTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3B695192D0D479B8D41DDE1F /* SKConversation.h in Headers */ = {isa = PBXBuildFile; fileRef = 57804134FAC62DB389FA867E /* SKConversation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3C58B90EC95D736ED534FCA6 /* SKClient+Account.h in Headers */ = {isa = PBXBuildFile; fileRef = 468545A3D0F59F8EB5EC8623 /* SKClient+Account.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3CDC1301650AE857C9735D00 /* Attestation.pb.h in Headers */ = {isa = PBXBuildFile; fileRef = BC234E8391D1425381C05523 /* Attestation.pb.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3D38403CF9EF75026E6BB743 /* UnknownFieldSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A2AAA454116F315A4C5A440 /* UnknownFieldSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3E39024EF3E9E21F4D1F9B41 /* NSValueTransformer+MTLInversionAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C7985E1F9182ABE6BA9D3DE /* NSValueTransformer+MTLInversionAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		3E7B7B4F2C1BD392B7EE4097 /* CodedOutputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F89D17AA09083FFEC8C72CF /* CodedOutputStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3E804385D91DCA559F4A05CA /* Utilities.h in Headers */ = {isa = PBXBuildFile; fileRef = B758A255FCB12557BF687DBF /* Utilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3EE3B22425A0AD7CCE863F6C /* zip.h in Headers */ = {isa = PBXBuildFile; fileRef = 36535381D153E491915E5B96 /* zip.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3F1A535C076C0CABB5A672AB /* SSZipArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = 9580C868D4BD628B16033847 /* SSZipArchive.m */; };
-		403DD822CB5BE84002AB3697 /* Pods-SnapchatKit_Example-Mantle-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A7C23396CBC972AE283C6179 /* Pods-SnapchatKit_Example-Mantle-dummy.m */; };
-		40EFC64A3862973D10088FA5 /* SKRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = FB3E8A3A6BAD4DE5DB3BD0B3 /* SKRequest.m */; };
-		4106B74202118E3E0D6E57C5 /* AbstractMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = C55205D98ACA2596E3A93000 /* AbstractMessage.m */; };
-		4293B45814FE9F05BBC8A738 /* Attestation.pb.m in Sources */ = {isa = PBXBuildFile; fileRef = E4C61B7D956E59989273650A /* Attestation.pb.m */; };
-		4297713E2C1E560D876CBD9E /* SKLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BD6662AFDE6D73BB17E57D0 /* SKLocation.m */; };
-		42A1E33E81B72588A8D75E30 /* CodedInputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D2A3B038ECCCA6DF6D3B46B /* CodedInputStream.m */; };
-		42B6CF04AC560E93F72C0731 /* SKClient+Snaps.m in Sources */ = {isa = PBXBuildFile; fileRef = C59B176424A659FA44EB301D /* SKClient+Snaps.m */; };
-		42B980F643FA3241F4910C0F /* SKAddedFriend.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CB417E7FA3A2177453C0458 /* SKAddedFriend.m */; };
-		42F5C0E40F2E2AA61CA25943 /* Pods-SnapchatKit_Tests-Mantle-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 138BBC48171ED63193A16737 /* Pods-SnapchatKit_Tests-Mantle-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		440E6F2CBA776F99583AC306 /* NSDictionary+MTLMappingAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = B4399388D431562C74758070 /* NSDictionary+MTLMappingAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		44535CF5C1977174A22B289F /* SKSharedStoryDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = F1D451149D1CCB912DFC59DA /* SKSharedStoryDescription.m */; };
-		46C648FFE943323327B87AF8 /* SKBlob.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A08CC8E2AC99F2D225D628E /* SKBlob.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		471606E4FD2D8C41AAF4C29D /* SKStoryUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = AD9CE5C7E8B71B7A717BF7CF /* SKStoryUpdater.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		471D420705E3110EBC6D773D /* Utilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 11064E9E55CF944B7E747575 /* Utilities.m */; };
-		47BB125E9D808519F925A9A6 /* SKUserStory.m in Sources */ = {isa = PBXBuildFile; fileRef = 90F41EB5F4D4C93EFA06977B /* SKUserStory.m */; };
-		47D9CC31665365AD34DF8AE7 /* SKClient+Chat.m in Sources */ = {isa = PBXBuildFile; fileRef = 31201F9C36DCB8072A773375 /* SKClient+Chat.m */; };
-		480EC581AA37FC8B7F6BE7D7 /* SKStoryNote.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CC5CD60538DCDD4998B4E9D /* SKStoryNote.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		486D421873C1B9EB84545DE9 /* SKNewConversation.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FFFD75623FB9218D73DE323 /* SKNewConversation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4AABECA1DD2F52EB775C78B1 /* MutableField.m in Sources */ = {isa = PBXBuildFile; fileRef = FEAB71425CD10455E6D75F28 /* MutableField.m */; };
-		4B659BE8421CB710C5AD046C /* SKClient+Device.h in Headers */ = {isa = PBXBuildFile; fileRef = F1DE6FC4BDB289A1735EC820 /* SKClient+Device.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4B7BBA9F1667A9574DD6718F /* SKUserStory.h in Headers */ = {isa = PBXBuildFile; fileRef = FD60E62E28DCF876A104F0A7 /* SKUserStory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4C5A393E54055B0D535FF7C5 /* MutableExtensionRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D85386BB83B94415BF95032 /* MutableExtensionRegistry.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4C5DBC648CE953302700075F /* CodedInputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D2A3B038ECCCA6DF6D3B46B /* CodedInputStream.m */; };
-		4C905F9F681ACA5EB62F1365 /* ObjectivecDescriptor.pb.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B450E93CAE222E73572A5BA /* ObjectivecDescriptor.pb.m */; };
-		4CAD2371504A623AA8572F91 /* SKNearbyUser.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C7595A2095D32ABE35F10FE /* SKNearbyUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4D0934FCE4433948918697F7 /* ExtendableMessageBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 676BE47EFE38F1493CD05107 /* ExtendableMessageBuilder.m */; };
-		4DEFF07D030E467E4EBD032B /* mztools.h in Headers */ = {isa = PBXBuildFile; fileRef = 6D9B66EB6E20F1C7D4AD8AA0 /* mztools.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4ED0D422BE9EFE3FB27EE656 /* SKStoryOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = F9884910EFC1C632C163D4E9 /* SKStoryOptions.m */; };
-		4EFB4BCCB7AEFFA041622493 /* SKUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B86948413F2BA125B8C7D03 /* SKUser.m */; };
-		4F39A78CF6393D0318613C25 /* NSString+SnapchatKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 74DA603BC9A41DF99F80FF9C /* NSString+SnapchatKit.m */; };
-		50B5518E4870A1108B44AB3E /* RingBuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D12E82F0CEA77B8F7DE1F9B /* RingBuffer.m */; };
-		50C75D1CDB8FE9CE73B70737 /* SKUser.h in Headers */ = {isa = PBXBuildFile; fileRef = 5ED60ED9A8DEB4AF13B67CC8 /* SKUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		517C68C58DAFA6D045161FB9 /* SKClient+Friends.m in Sources */ = {isa = PBXBuildFile; fileRef = A1ACEF81DAC35F3667E86099 /* SKClient+Friends.m */; };
-		51E18CC0CF4E4BFCEC46AAE1 /* ExtensionField.h in Headers */ = {isa = PBXBuildFile; fileRef = 57779D995D4EED4517C14162 /* ExtensionField.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		51FB1B59AAE95DB52FCF341D /* NSString+SnapchatKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 74DA603BC9A41DF99F80FF9C /* NSString+SnapchatKit.m */; };
-		5268AF77C2E16BC562DDCBF7 /* SKClient+Snaps.h in Headers */ = {isa = PBXBuildFile; fileRef = E4DD12BC1374B1D0F8A542E6 /* SKClient+Snaps.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		52ACE1B20DF8D17424EC8FB1 /* ObjectivecDescriptor.pb.h in Headers */ = {isa = PBXBuildFile; fileRef = F9218CE3AF46DF110AC1FC93 /* ObjectivecDescriptor.pb.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5332A70E9EA896599F37F098 /* NSDictionary+MTLMappingAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = B74CCA0F13F010EF6C5F3108 /* NSDictionary+MTLMappingAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5376161389203A8367405598 /* UnknownFieldSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A2AAA454116F315A4C5A440 /* UnknownFieldSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		53DF2E946BDA366FE5CE98C7 /* SKClient+Device.m in Sources */ = {isa = PBXBuildFile; fileRef = B82E05A3E46B11BD9BF8921D /* SKClient+Device.m */; };
-		549FC1A5B80D8A12B02055D2 /* MTLModel.h in Headers */ = {isa = PBXBuildFile; fileRef = FF09072CAEC86883CBD1C5B7 /* MTLModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		54CDEC3BC81A87929AFCBB13 /* EXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 515761136CC4D2DA31CBDCCE /* EXTRuntimeExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		553FC487B0E329BD1564216E /* SKSnapOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = B97745F20B56DFE00D4434D7 /* SKSnapOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		55BEBECB11A566F84D6ACDFD /* MTLModel+NSCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = C49BF5D2D648742FCBBC6433 /* MTLModel+NSCoding.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5606FD756288DFDA95C11EFC /* MTLReflection.h in Headers */ = {isa = PBXBuildFile; fileRef = 9EBA09F0C92556545D654BDD /* MTLReflection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		566406164ADB5D858AC2220C /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 825834A937BE3CAE02AB2EB9 /* Cocoa.framework */; };
-		578204BBCA8628A0B524BA5E /* GeneratedMessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 116CA5F3E415255E8D2A4C6B /* GeneratedMessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		57D4362A502BEA75B844EE47 /* MTLTransformerErrorHandling.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E2EF527D485AA3518965377 /* MTLTransformerErrorHandling.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		584689C9DDEAE8E320117B0D /* NSDictionary+MTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = D62E5A585E176727B114DBF8 /* NSDictionary+MTLManipulationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		585F21583D81D9D150F9AC42 /* Mantle.h in Headers */ = {isa = PBXBuildFile; fileRef = E143F32D6FBEF9E2E0AD119E /* Mantle.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		58CA4F8819B0DDB21CCD337B /* SKSnapOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 00F7E64375D906AADEEBE012 /* SKSnapOptions.m */; };
-		58DD3E186257389F527CBB80 /* Pods-SnapchatKit_Example-SnapchatKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = ABEFC3F1ABD4E8AFE75B8DF3 /* Pods-SnapchatKit_Example-SnapchatKit-dummy.m */; };
-		59BD70D83CBEECADBBF3805D /* CodedOutputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 90D507AAE40D2CEED0D36687 /* CodedOutputStream.m */; };
-		5A373D7A27930DCCC86D125B /* NSData+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 9BE3B4334F276CA5FE417047 /* NSData+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5A7B293C4D887F512E40BB28 /* SKSharedStoryDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 8FD3C16495412F844A298EA3 /* SKSharedStoryDescription.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5A8779F2571F131EFBB1DA4F /* SKRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = FB3E8A3A6BAD4DE5DB3BD0B3 /* SKRequest.m */; };
-		5AC65D12FCAA8F149C44D9AB /* SnapchatKit-Constants.m in Sources */ = {isa = PBXBuildFile; fileRef = 60FCE66689CCF5D0D0C98357 /* SnapchatKit-Constants.m */; };
-		5AD9EAC65D102620FFE86A19 /* UnknownFieldSet.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DD52DE4A9AAD6E3A69EB894 /* UnknownFieldSet.m */; };
-		5B3C2B89740DD789627ADB84 /* SKClient+Stories.m in Sources */ = {isa = PBXBuildFile; fileRef = 17D0AA7AA0EA6CC242B330F9 /* SKClient+Stories.m */; };
-		5B7461D9762C96AA9F885F7C /* Descriptor.pb.h in Headers */ = {isa = PBXBuildFile; fileRef = B5F8AE9D9CC92F9D2639DE69 /* Descriptor.pb.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5BA2F898C5F5CF7DF9A5C87D /* ExtensionField.h in Headers */ = {isa = PBXBuildFile; fileRef = 57779D995D4EED4517C14162 /* ExtensionField.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5C164DCB636CD888466BABA6 /* NSValueTransformer+MTLInversionAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 79892EA1B4AA29856078EE35 /* NSValueTransformer+MTLInversionAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5C3C68C913BF5EC42418EB1F /* SKSimpleUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 022825FCF2BAF08416579518 /* SKSimpleUser.m */; };
-		5CF80F721AF87A2540F0DDAE /* Pods-SnapchatKit-OSX-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 503F98FEAAC39B02E3C4B2F1 /* Pods-SnapchatKit-OSX-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5D692C915F9C7548390556A6 /* SKSnapResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 123AA38787CE03C6CCCD59EF /* SKSnapResponse.m */; };
-		5D8C1DDA41E3CA90029702BF /* MutableExtensionRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DC7CD3FB2E0D2C3AF55E726 /* MutableExtensionRegistry.m */; };
-		5F1C9BF96C16E4DDF4211650 /* ExtendableMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 81D3C8E6CF0E4B9EC98608DF /* ExtendableMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5FBBA230C00348169F58CCBE /* metamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 0AA75375F2F52C8E60ABBCCB /* metamacros.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		60E2CFC4AFDDF93E438833C0 /* ioapi.c in Sources */ = {isa = PBXBuildFile; fileRef = 0A8FA92E556068A6CE1CCE16 /* ioapi.c */; };
-		611D58FC6C7E8C52C04B2A7E /* MTLValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8EE2DC94841F1D57870388D7 /* MTLValueTransformer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		617D3D3FEDD53C229199D369 /* NSDictionary+MTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = D62E5A585E176727B114DBF8 /* NSDictionary+MTLManipulationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6180146A0E12D0F5F6725D62 /* GeneratedMessageBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = A22019B34FF3D28330B16DF5 /* GeneratedMessageBuilder.m */; };
-		628CFEBAEC6DD114FC023FD0 /* SKSession.m in Sources */ = {isa = PBXBuildFile; fileRef = E258F52BF2199045E866A6F0 /* SKSession.m */; };
-		6290EDFFD99F77DD4AD24A77 /* NSError+MTLModelException.m in Sources */ = {isa = PBXBuildFile; fileRef = EDDC5E23649AF7A1E0BB82E8 /* NSError+MTLModelException.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		62C5851BD4E387FD75A22EF7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01A3D282D76F2492158972A9 /* Foundation.framework */; };
-		630495DC5633CA5447F7121C /* SKClient+Discover.m in Sources */ = {isa = PBXBuildFile; fileRef = DCDA93F546D12297EA015005 /* SKClient+Discover.m */; };
-		6344AE8E0B2148C2AD213F99 /* Pods-SnapchatKit_Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = C3CACC2CC8A6328EED00102F /* Pods-SnapchatKit_Tests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		638BCA064214B5E2AC40EB82 /* SKBlob.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A08CC8E2AC99F2D225D628E /* SKBlob.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		646891B8E56D239FD9BA7B0D /* AbstractMessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 40971082BAA72F1F1EDAF695 /* AbstractMessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6529D3442D33DC391529BAC1 /* Pods-SnapchatKit_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 31356904078AF381495527D2 /* Pods-SnapchatKit_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		65B81FB78039585AD03EE5F8 /* SKStory.m in Sources */ = {isa = PBXBuildFile; fileRef = 346F22DD245A0A72527AE1C8 /* SKStory.m */; };
-		66155514E28D8F2E4529EC37 /* ExtendableMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 6070FF02167CEB9FC7458D39 /* ExtendableMessage.m */; };
-		670BA54D9EEC3A0F861E92D1 /* EXTScope.m in Sources */ = {isa = PBXBuildFile; fileRef = 74DF1D6CA9D178F9CEE62E29 /* EXTScope.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		67449BF0401EFDA39FC887ED /* metamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 0AA75375F2F52C8E60ABBCCB /* metamacros.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		675A0D829DF7ADEC8AD8D480 /* SKClient+Friends.m in Sources */ = {isa = PBXBuildFile; fileRef = A1ACEF81DAC35F3667E86099 /* SKClient+Friends.m */; };
-		676514B614CDDC7C302A71E4 /* SKSession.m in Sources */ = {isa = PBXBuildFile; fileRef = E258F52BF2199045E866A6F0 /* SKSession.m */; };
-		67A6F9BDF98BC4FCEA9AA9C6 /* SKFoundFriend.h in Headers */ = {isa = PBXBuildFile; fileRef = 607499C80038757E311F8CA1 /* SKFoundFriend.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		681A3DD19662F0E438CD6B02 /* SKConversation.h in Headers */ = {isa = PBXBuildFile; fileRef = 57804134FAC62DB389FA867E /* SKConversation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6857116CB2C09268AF4038CE /* MTLReflection.m in Sources */ = {isa = PBXBuildFile; fileRef = B0A48052AEB65F7B647DB473 /* MTLReflection.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		6880312805F61A669E5BA40F /* Field.m in Sources */ = {isa = PBXBuildFile; fileRef = 549084617E4D5DCBD4ED4B0E /* Field.m */; };
-		68F3AEB506E259448F2AB64B /* AbstractMessageBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 35EF0345D98539E68C6DCCF0 /* AbstractMessageBuilder.m */; };
-		698A388303485E89AA5E7E62 /* MessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 0746351ADCB0B21FE32B2E85 /* MessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6A304AE2999F736F8CB71C13 /* EXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C23DFF2F44056D492331988 /* EXTRuntimeExtensions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		6A3AFDEEBFAF907DA4ABF231 /* SKStoryCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F6C4F7854C482C05E42ED2B /* SKStoryCollection.m */; };
-		6A9D067C56CFA0118840C63C /* SKNearbyUser.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C7595A2095D32ABE35F10FE /* SKNearbyUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6AEB75DB255B4DF7F68AE676 /* PBArray.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A0970111F805282AEC6CAD /* PBArray.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6B099A244F1A4DC3F81D39DC /* CodedInputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 29CFD017511A61FDEEFEF7FB /* CodedInputStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6B2A82CF0AE453844C7FC6D1 /* SKClient+Discover.h in Headers */ = {isa = PBXBuildFile; fileRef = FCA6532B428B695F70814807 /* SKClient+Discover.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6B58BF1919C0462B73F9D8C1 /* SKSharedStoryDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = F1D451149D1CCB912DFC59DA /* SKSharedStoryDescription.m */; };
-		6B7BADCAF5D27A81763A2175 /* ConcreteExtensionField.h in Headers */ = {isa = PBXBuildFile; fileRef = 53E643E4011CFF791437DE5C /* ConcreteExtensionField.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6B816E0C33065EB99D14EDF4 /* MTLJSONAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = CD40B957499A960C0F251F7A /* MTLJSONAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6B931A3FA0D8CF9929B52335 /* SKThing.m in Sources */ = {isa = PBXBuildFile; fileRef = 480232BB439E70191B69829A /* SKThing.m */; };
-		6C3B5FCF95765E60FAB3DDC3 /* Bootstrap.h in Headers */ = {isa = PBXBuildFile; fileRef = 7183BB0F3292AEE43022E891 /* Bootstrap.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6CE8D42C300780F1E60058FE /* SKSnap.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FF03725A1FBD01F3B54D410 /* SKSnap.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6D6FDF00ADF44F0A7CD7BBD4 /* SKClient+Snaps.h in Headers */ = {isa = PBXBuildFile; fileRef = E4DD12BC1374B1D0F8A542E6 /* SKClient+Snaps.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6E1993144F1BE026FEF00012 /* SKNewConversation.m in Sources */ = {isa = PBXBuildFile; fileRef = 150E0D42F8ADD64688F5FF77 /* SKNewConversation.m */; };
-		6E2BACB518B4B5A3CB6B12D5 /* EXTScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D4A7091C6DE37C14EBE847D /* EXTScope.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		6E4C2B3721D3A314F9D6F291 /* ExtendableMessageBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 676BE47EFE38F1493CD05107 /* ExtendableMessageBuilder.m */; };
-		6ECC478906622A6C4BBC72FB /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 825834A937BE3CAE02AB2EB9 /* Cocoa.framework */; };
-		6EFB2FC259374AA1344DDADF /* ObjectivecDescriptor.pb.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B450E93CAE222E73572A5BA /* ObjectivecDescriptor.pb.m */; };
-		6F0B2284146B9BD538202D12 /* NSData+SnapchatKit.m in Sources */ = {isa = PBXBuildFile; fileRef = DA7D052FF7B5D4F9FAB6264F /* NSData+SnapchatKit.m */; };
-		6FBDFDB7C5D7251A2AF79F0D /* SKBlob.m in Sources */ = {isa = PBXBuildFile; fileRef = C72DBD7A6DA7655074E62D29 /* SKBlob.m */; };
-		7255780A10ED06ACCF0B4E64 /* mztools.c in Sources */ = {isa = PBXBuildFile; fileRef = 7137BB5CBC818BC0E912BAE8 /* mztools.c */; };
-		73B08A70FD2A9CDD08114B9C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01A3D282D76F2492158972A9 /* Foundation.framework */; };
-		743338848BB23E48AAA68AA4 /* GeneratedMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = F6310B7A8D4CCC215C36FC42 /* GeneratedMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		74AA33D29C0139BE8668A1D2 /* SKSnapResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = F128C2CF8C3AF119EF791658 /* SKSnapResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7526B412A582D3D940F7E4F2 /* SKLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CE06043D4DC81317EE540DE /* SKLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7544B5BD24E53FB0911CFBE2 /* NSDictionary+MTLMappingAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = B4399388D431562C74758070 /* NSDictionary+MTLMappingAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		7583330B7DC2FA5348694610 /* Field.m in Sources */ = {isa = PBXBuildFile; fileRef = 549084617E4D5DCBD4ED4B0E /* Field.m */; };
-		7671D7F5146DD4E6EBD5AF5D /* SKStory.h in Headers */ = {isa = PBXBuildFile; fileRef = 76CC3491B3E0E22C56D21730 /* SKStory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		76CFA3E5EB0B4045C3315F83 /* ConcreteExtensionField.h in Headers */ = {isa = PBXBuildFile; fileRef = 53E643E4011CFF791437DE5C /* ConcreteExtensionField.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		77A18B03292BF020A78F2D73 /* RingBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = AA149B4D211D5124D4002334 /* RingBuffer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7825A05C79A0E11D19144990 /* SKThing.h in Headers */ = {isa = PBXBuildFile; fileRef = FF2964E8E281C6629782BFF8 /* SKThing.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		78E3F8BFDF69D3BC6E224C87 /* SKCashTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = EBAC7CF928D68AD3EE37FB4D /* SKCashTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		79D1FB1DC62DF225E8B20813 /* NSObject+MTLComparisonAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = E3F90C74F6B4513DB6B80D92 /* NSObject+MTLComparisonAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		7A0A51884FE62E3E94709D2F /* zip.c in Sources */ = {isa = PBXBuildFile; fileRef = EB9C7549B766712AC0F5F9F7 /* zip.c */; };
-		7A5BF8BC10692D2E04DF6C09 /* SKSnap.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E8F65183882F17A3EE5BA5D /* SKSnap.m */; };
-		7B0BFD79B7BF6CD3EF44EB5B /* SKUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B86948413F2BA125B8C7D03 /* SKUser.m */; };
-		7B222445F766286395C8C341 /* MutableExtensionRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D85386BB83B94415BF95032 /* MutableExtensionRegistry.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7BBCC272CE768303CDA282F0 /* SKFoundFriend.m in Sources */ = {isa = PBXBuildFile; fileRef = B71A42ED9C9A282E7A4B4542 /* SKFoundFriend.m */; };
-		7CB5BD6859D70E2152116676 /* metamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 0AA75375F2F52C8E60ABBCCB /* metamacros.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		7D2CB385C94CD9F534ABF670 /* EXTKeyPathCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = A9FBC3803D641A8AF3A1A033 /* EXTKeyPathCoding.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		7DC1BB222E06AAFE6A3D9EE8 /* Pods-SnapchatKit-OSX-SnapchatKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D2B9EB3ED194082F399A655 /* Pods-SnapchatKit-OSX-SnapchatKit-dummy.m */; };
-		7DDA900B32D8FD0A92B93721 /* SKClient+Device.m in Sources */ = {isa = PBXBuildFile; fileRef = B82E05A3E46B11BD9BF8921D /* SKClient+Device.m */; };
-		7E022FCEC5F8DF32A8322A10 /* SKUserStory.m in Sources */ = {isa = PBXBuildFile; fileRef = 90F41EB5F4D4C93EFA06977B /* SKUserStory.m */; };
-		7E14D8E7DA87BCBC8B978052 /* Field.h in Headers */ = {isa = PBXBuildFile; fileRef = F347842C5587B36F931554EC /* Field.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7E49A8205F13F85517E48379 /* SKSnapResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 123AA38787CE03C6CCCD59EF /* SKSnapResponse.m */; };
-		7EA515CDA613A305F4CD4A69 /* Message.h in Headers */ = {isa = PBXBuildFile; fileRef = 90BEF1EF981624D8235EE9E6 /* Message.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7EAEE9BC93527594528B47A4 /* MTLTransformerErrorHandling.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F3BDE1CAA9A717200841609 /* MTLTransformerErrorHandling.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		7F09D4189868DEA572DDD9EF /* SKClient.h in Headers */ = {isa = PBXBuildFile; fileRef = AD3C9AC8DBADBCAB8DA86DA8 /* SKClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7F371105CBC54F6F299D3004 /* SKRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = FB3E8A3A6BAD4DE5DB3BD0B3 /* SKRequest.m */; };
-		7FA2583B70C4F5D4B9E6E6D2 /* UnknownFieldSetBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 71577F1A49CF27CC9FA94074 /* UnknownFieldSetBuilder.m */; };
-		7FF094D15285DE4A872C5E26 /* CodedInputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D2A3B038ECCCA6DF6D3B46B /* CodedInputStream.m */; };
-		804328A51D200ED84D97E70A /* MTLModel.m in Sources */ = {isa = PBXBuildFile; fileRef = E2FB4A4D3FF57F7B9A0C482C /* MTLModel.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		80462C60BFEACE3C75307F59 /* ExtendableMessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 8F10C5B94F9F3FF19B6B285D /* ExtendableMessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8121979E3B0028D51D1E7A42 /* SKAddedFriend.h in Headers */ = {isa = PBXBuildFile; fileRef = A766840A3FA15875DD115B84 /* SKAddedFriend.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81A2A5A04991182D22D75265 /* ForwardDeclarations.h in Headers */ = {isa = PBXBuildFile; fileRef = 5F96C5D607778F1ABE0AA9A9 /* ForwardDeclarations.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81BB9979F15ADBF4D54D2B6E /* GeneratedMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = F6310B7A8D4CCC215C36FC42 /* GeneratedMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81C9593A578A9A1D8F757C43 /* SKFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CC372A04E32E3B5A10B6683 /* SKFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8252E835FA73E096BAFAB160 /* SKCashTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = 21D7027B0107A87B98B269DD /* SKCashTransaction.m */; };
-		82AD8A369B282249F17A3093 /* SKClient+Account.m in Sources */ = {isa = PBXBuildFile; fileRef = 36ECBA089FD3718EDC1195C0 /* SKClient+Account.m */; };
-		82EE91123D8CCAC2C1558E81 /* Bootstrap.h in Headers */ = {isa = PBXBuildFile; fileRef = 7183BB0F3292AEE43022E891 /* Bootstrap.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		840A18B6ADD004B75B454D56 /* NSValueTransformer+MTLInversionAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C7985E1F9182ABE6BA9D3DE /* NSValueTransformer+MTLInversionAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		854D8D6ABABF603B3E69F82D /* unzip.h in Headers */ = {isa = PBXBuildFile; fileRef = 366DC11AD62752B2C3E9393B /* unzip.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		86E7E149F294F2A0E0D8E6ED /* NSArray+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 7718349A691AC354D56DB602 /* NSArray+MTLManipulationAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		87A6F25731BD3F71C1A37887 /* SKSnap.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FF03725A1FBD01F3B54D410 /* SKSnap.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		87D3F8EF8EAF95C434206292 /* NSDictionary+MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = E1DC65C5D930DE74DF698A83 /* NSDictionary+MTLJSONKeyPath.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		896058141FA3B9D1470B59D5 /* ExtensionRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 679719A8EC9FC6E3B23D6151 /* ExtensionRegistry.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A1485F41B99AE7111FDBBA6 /* CodedOutputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F89D17AA09083FFEC8C72CF /* CodedOutputStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8AC2B44A34D3C1B0BCA165BB /* mztools.c in Sources */ = {isa = PBXBuildFile; fileRef = 7137BB5CBC818BC0E912BAE8 /* mztools.c */; };
-		8B96E3DB2C7350B9B86643DB /* SKClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E47188605DEAD31B32CA84A /* SKClient.m */; };
-		8B993B6448D2B6AA750D833B /* NSValueTransformer+MTLInversionAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C7985E1F9182ABE6BA9D3DE /* NSValueTransformer+MTLInversionAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		8BBABED701E56C76FADB8093 /* SKClient+Stories.h in Headers */ = {isa = PBXBuildFile; fileRef = 0352130AD3816023F8068ECA /* SKClient+Stories.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8BE2EBBE2CE3CD118E52E6B6 /* Attestation.pb.m in Sources */ = {isa = PBXBuildFile; fileRef = E4C61B7D956E59989273650A /* Attestation.pb.m */; };
-		8C105CDC97E22B3017AC771F /* AbstractMessageBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 35EF0345D98539E68C6DCCF0 /* AbstractMessageBuilder.m */; };
-		8C2F856DF57CA3BB07C2CDD7 /* UnknownFieldSetBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 71577F1A49CF27CC9FA94074 /* UnknownFieldSetBuilder.m */; };
-		8D4C6F8B84F09B604C58B72B /* SKClient+Chat.h in Headers */ = {isa = PBXBuildFile; fileRef = F552284B16EA501247330C10 /* SKClient+Chat.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8D92B657B7C2FB299693265D /* MTLReflection.m in Sources */ = {isa = PBXBuildFile; fileRef = B0A48052AEB65F7B647DB473 /* MTLReflection.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		8DA97A20569F938904D3387D /* NSValueTransformer+MTLPredefinedTransformerAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = E85AA3FDA1B47E649DCA1DD1 /* NSValueTransformer+MTLPredefinedTransformerAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8E4E8FC6AD604D3D52214C0C /* SKUserStory.h in Headers */ = {isa = PBXBuildFile; fileRef = FD60E62E28DCF876A104F0A7 /* SKUserStory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8F99E1FB81BE65EAD3BFBD2E /* NSDictionary+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7CA746CADA1BDA8DFD79E9 /* NSDictionary+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		905405274F0D710675CED6CF /* SnapchatKit-Constants.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A4E677C0A6B08357EDE38B3 /* SnapchatKit-Constants.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		91F29EA14084608557703C9A /* NSDictionary+SnapchatKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 1EDA4E519FE1136F8E6159C2 /* NSDictionary+SnapchatKit.m */; };
-		92F6966CBEFD4BC08913916A /* MTLModel.m in Sources */ = {isa = PBXBuildFile; fileRef = E2FB4A4D3FF57F7B9A0C482C /* MTLModel.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		93295C2A46E89261B0A859A5 /* NSDictionary+MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = E1DC65C5D930DE74DF698A83 /* NSDictionary+MTLJSONKeyPath.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		93DBEC6F8771645542396EDE /* Pods-SnapchatKit_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F9C3899FAAC648953D8E96C /* Pods-SnapchatKit_Example-dummy.m */; };
-		94200A642B2CAA9401D84B46 /* SKSnapOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 00F7E64375D906AADEEBE012 /* SKSnapOptions.m */; };
-		94343B934AAECDDB1F7BC4CF /* SKConversation.m in Sources */ = {isa = PBXBuildFile; fileRef = 701146DB20AFF386866AA783 /* SKConversation.m */; };
-		9471842034EAE351B3317A83 /* TextFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 3BE6AF84EBA6D92BCE5C7636 /* TextFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		948D462CECAEAA00FDDE82B8 /* ExtendableMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 81D3C8E6CF0E4B9EC98608DF /* ExtendableMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		94E186BF12C395C218B79704 /* MutableField.m in Sources */ = {isa = PBXBuildFile; fileRef = FEAB71425CD10455E6D75F28 /* MutableField.m */; };
-		953EF891B8DAC44FA84D91C6 /* SKStoryUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = F2DB5DC9CB68ABDBF1C8F8AE /* SKStoryUpdater.m */; };
-		95B380800202575D7E585813 /* SKClient+Discover.m in Sources */ = {isa = PBXBuildFile; fileRef = DCDA93F546D12297EA015005 /* SKClient+Discover.m */; };
-		96A2E570D3F84D721D844E47 /* SKMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = EB8FB810CD3E9AF9303846D2 /* SKMessage.m */; };
-		96B213BB0D4D147DE253B765 /* NSDictionary+MTLMappingAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = B74CCA0F13F010EF6C5F3108 /* NSDictionary+MTLMappingAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9820D90B6652840197F5547E /* EXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C23DFF2F44056D492331988 /* EXTRuntimeExtensions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		986C7B2B29F2654B112BFDC4 /* SKSnapOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = B97745F20B56DFE00D4434D7 /* SKSnapOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		997BF0B5D6FFD67A5F64A174 /* NSError+MTLModelException.m in Sources */ = {isa = PBXBuildFile; fileRef = EDDC5E23649AF7A1E0BB82E8 /* NSError+MTLModelException.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		99ED3EBA5670BFB8647DE4CD /* SKCashTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = 21D7027B0107A87B98B269DD /* SKCashTransaction.m */; };
-		99F7A57C6C4B1D5B1E65B27E /* MTLModel.h in Headers */ = {isa = PBXBuildFile; fileRef = FF09072CAEC86883CBD1C5B7 /* MTLModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9AE79C6A27C3558522A38CA2 /* SKStoryUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = F2DB5DC9CB68ABDBF1C8F8AE /* SKStoryUpdater.m */; };
-		9B08F940FD85FEAB7BD42D06 /* SKConversation.h in Headers */ = {isa = PBXBuildFile; fileRef = 57804134FAC62DB389FA867E /* SKConversation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9BC9A54C47418873460CF88C /* Pods-SnapchatKit_Tests-Mantle-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = DA1D849137C33690C52103DA /* Pods-SnapchatKit_Tests-Mantle-dummy.m */; };
-		9C06EAC9C04252DD0D6081BF /* Descriptor.pb.m in Sources */ = {isa = PBXBuildFile; fileRef = 53358FC1AF684CCB6202172F /* Descriptor.pb.m */; };
-		9D046D771EB1133294D03A0F /* SKConversation.m in Sources */ = {isa = PBXBuildFile; fileRef = 701146DB20AFF386866AA783 /* SKConversation.m */; };
-		9D06F6B5BE77890EB29C987F /* WireFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = E6DCF7D3DF29FF7F743F3642 /* WireFormat.m */; };
-		9E8D11CFD584508E14B5A79D /* NSArray+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 7718349A691AC354D56DB602 /* NSArray+MTLManipulationAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		9EABA487066E7FC9A9E75992 /* SKClient+Friends.h in Headers */ = {isa = PBXBuildFile; fileRef = CD7CF6D3EDE14721A9FA183B /* SKClient+Friends.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A04BD24C2E0D3887BBDB74F3 /* NSArray+MTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 4762A159FAA8CE845790577D /* NSArray+MTLManipulationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A0A6E92758A1310817B63D11 /* SKClient+Friends.h in Headers */ = {isa = PBXBuildFile; fileRef = CD7CF6D3EDE14721A9FA183B /* SKClient+Friends.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A1F7B0A61E32B0FA5CD46C6F /* Utilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 11064E9E55CF944B7E747575 /* Utilities.m */; };
-		A227027126993D119E9B36CB /* EXTScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D4A7091C6DE37C14EBE847D /* EXTScope.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		A372C848180F614A291B7BD6 /* unzip.c in Sources */ = {isa = PBXBuildFile; fileRef = 367E68898317851726B59744 /* unzip.c */; };
-		A398246401F4C9A16D0F18E0 /* SKClient+Snaps.m in Sources */ = {isa = PBXBuildFile; fileRef = C59B176424A659FA44EB301D /* SKClient+Snaps.m */; };
-		A425020C8D1C6E79BEA8345B /* mztools.h in Headers */ = {isa = PBXBuildFile; fileRef = 6D9B66EB6E20F1C7D4AD8AA0 /* mztools.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A60E58ADA6A60B126DC7B270 /* Field.m in Sources */ = {isa = PBXBuildFile; fileRef = 549084617E4D5DCBD4ED4B0E /* Field.m */; };
-		A78B4AB69095486609C94185 /* SKStoryCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = B475512FAECA1EDC22AF0197 /* SKStoryCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A7E34965805DA2DF39C90E8A /* GeneratedMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 6532EFC9D4874C91D352A810 /* GeneratedMessage.m */; };
-		A801A72F7F90D1BF04BD6E78 /* SKStoryUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = AD9CE5C7E8B71B7A717BF7CF /* SKStoryUpdater.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A85626E4ED29E3BB674FBCA5 /* AbstractMessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 40971082BAA72F1F1EDAF695 /* AbstractMessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A8C2B67DAC1EED2524ED0747 /* SnapchatKit-Constants.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A4E677C0A6B08357EDE38B3 /* SnapchatKit-Constants.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A8CE78B0E4865C5FC4228C58 /* Descriptor.pb.m in Sources */ = {isa = PBXBuildFile; fileRef = 53358FC1AF684CCB6202172F /* Descriptor.pb.m */; };
-		A9A3CA6A0785D40DFF6C871F /* SKSimpleUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 022825FCF2BAF08416579518 /* SKSimpleUser.m */; };
-		A9D3B6EC1E50EBCF7F1F1D65 /* SKFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = B3034C9C4729EFDDAF24276C /* SKFilter.m */; };
-		AB53B3893F6AE15899C49133 /* SKSession.h in Headers */ = {isa = PBXBuildFile; fileRef = 8ADC4AAB6A6ABCE48BCC5F84 /* SKSession.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AB86CF09AFD6CF6CE3E56C76 /* SKClient+Chat.h in Headers */ = {isa = PBXBuildFile; fileRef = F552284B16EA501247330C10 /* SKClient+Chat.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AC29F279D49B4D08C13A5CFE /* zip.c in Sources */ = {isa = PBXBuildFile; fileRef = EB9C7549B766712AC0F5F9F7 /* zip.c */; };
-		ACC4D3AACF9D3633F626814F /* GeneratedMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 6532EFC9D4874C91D352A810 /* GeneratedMessage.m */; };
-		ACE7050699B1F35113150D87 /* NSArray+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 7718349A691AC354D56DB602 /* NSArray+MTLManipulationAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		AD25763BBE8EB607A030CB90 /* SKClient+Account.h in Headers */ = {isa = PBXBuildFile; fileRef = 468545A3D0F59F8EB5EC8623 /* SKClient+Account.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AECE9F0E649E37204F298ABC /* MTLJSONAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = CD40B957499A960C0F251F7A /* MTLJSONAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AED94F6A79240EEFF1BA0A2D /* ExtendableMessageBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 676BE47EFE38F1493CD05107 /* ExtendableMessageBuilder.m */; };
-		AFB73EF9CD3A61FF120032CD /* NSArray+MTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 4762A159FAA8CE845790577D /* NSArray+MTLManipulationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AFEFA627888B6C5308D3A516 /* SKStoryOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 1198650DD0951EF6D7936CB7 /* SKStoryOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B00EF504907172878DF661E0 /* MTLTransformerErrorHandling.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F3BDE1CAA9A717200841609 /* MTLTransformerErrorHandling.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		B038E6A1C35A2FD5706664C8 /* ObjectivecDescriptor.pb.h in Headers */ = {isa = PBXBuildFile; fileRef = F9218CE3AF46DF110AC1FC93 /* ObjectivecDescriptor.pb.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B05C435EC718849BA6B8B6B2 /* Pods-SnapchatKit_Tests-SnapchatKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = E9AEA239EC2FAC0FBDB45EE7 /* Pods-SnapchatKit_Tests-SnapchatKit-dummy.m */; };
-		B0C2E8C14CD27BA805553C1C /* PBArray.m in Sources */ = {isa = PBXBuildFile; fileRef = D14F237EC025DFF27B83C274 /* PBArray.m */; };
-		B108138366AF5D0BF380F21B /* ConcreteExtensionField.h in Headers */ = {isa = PBXBuildFile; fileRef = 53E643E4011CFF791437DE5C /* ConcreteExtensionField.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B121C96D6C53B26DBF092336 /* SKRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 87DC6A533A3CB69CFE3FC6D8 /* SKRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B15765DC67F3D1270E293A8E /* zip.h in Headers */ = {isa = PBXBuildFile; fileRef = 36535381D153E491915E5B96 /* zip.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B23D03813A7C5BB065EA6B7A /* ForwardDeclarations.h in Headers */ = {isa = PBXBuildFile; fileRef = 5F96C5D607778F1ABE0AA9A9 /* ForwardDeclarations.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B255621DC1B525331E530359 /* NSError+MTLModelException.h in Headers */ = {isa = PBXBuildFile; fileRef = A91683F22FB4EF562527CCF8 /* NSError+MTLModelException.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B25A91900E2A68356DB93263 /* MTLJSONAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = CD40B957499A960C0F251F7A /* MTLJSONAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B3D44EB4CB0D39F511110084 /* SKStoryCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = B475512FAECA1EDC22AF0197 /* SKStoryCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B3ED9A6964AF2E38FBA5FF4D /* Pods-SnapchatKit_Example-Mantle-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A37A0F5E40E5D3D0B42D25A /* Pods-SnapchatKit_Example-Mantle-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B42683950415442E4BD3609B /* NSObject+MTLComparisonAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = AACC20FB1D0DE81D97FC7F46 /* NSObject+MTLComparisonAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B4E0BFDEC1FB9CB556200F19 /* EXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 515761136CC4D2DA31CBDCCE /* EXTRuntimeExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		B4ECE8867AE762DEF1B1E5BE /* ExtensionRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 1628AB0CEF6EECD372AA222B /* ExtensionRegistry.m */; };
-		B50A774F10B0F92F1696E576 /* EXTKeyPathCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = A9FBC3803D641A8AF3A1A033 /* EXTKeyPathCoding.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		B57DF02C279D103105DD7B77 /* ObjectivecDescriptor.pb.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B450E93CAE222E73572A5BA /* ObjectivecDescriptor.pb.m */; };
-		B590F05A10D57282ADF6DCFD /* SKSnap.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E8F65183882F17A3EE5BA5D /* SKSnap.m */; };
-		B6116BF0443C7AA69573228C /* NSDictionary+MTLMappingAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = B4399388D431562C74758070 /* NSDictionary+MTLMappingAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		B66868E9085D0BC5B40B1175 /* crypt.h in Headers */ = {isa = PBXBuildFile; fileRef = 34BDFDCAB53D1C3DF3D8B643 /* crypt.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B7070ED6FB7CB05A09889145 /* SKThing.h in Headers */ = {isa = PBXBuildFile; fileRef = FF2964E8E281C6629782BFF8 /* SKThing.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B7D01A61247038E49A62FF7A /* ConcreteExtensionField.m in Sources */ = {isa = PBXBuildFile; fileRef = 7604B3135534C28027647CD5 /* ConcreteExtensionField.m */; };
-		B810C1D1A95D49514E619D05 /* SKSharedStoryDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = F1D451149D1CCB912DFC59DA /* SKSharedStoryDescription.m */; };
-		B82678C1921C2BA1FF24FD7D /* MutableField.h in Headers */ = {isa = PBXBuildFile; fileRef = B359AC7608C8680235607B64 /* MutableField.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B8F14AB0C53E0A3F6F4BE91D /* TextFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 3BE6AF84EBA6D92BCE5C7636 /* TextFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B94B6BC9B81410655B4C45FB /* SKStoryNote.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CC5CD60538DCDD4998B4E9D /* SKStoryNote.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B966837BEE99D257E6A53925 /* CodedOutputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 90D507AAE40D2CEED0D36687 /* CodedOutputStream.m */; };
-		B96BAB1FF1CFA4761D105B57 /* ForwardDeclarations.h in Headers */ = {isa = PBXBuildFile; fileRef = 5F96C5D607778F1ABE0AA9A9 /* ForwardDeclarations.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B96CA04AAE1225CF696FAA66 /* WireFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = E6DCF7D3DF29FF7F743F3642 /* WireFormat.m */; };
-		B97CFDE2A57EFCB2AE6BC211 /* UnknownFieldSetBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = AAEE9103C8BA8123534B7278 /* UnknownFieldSetBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B9C9CE113960D2E0A67543CF /* WireFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 91FD8FDCB1EF8E5342243FB7 /* WireFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BA2E0F490A58DB25DE7187FA /* SKClient+Account.m in Sources */ = {isa = PBXBuildFile; fileRef = 36ECBA089FD3718EDC1195C0 /* SKClient+Account.m */; };
-		BBB953F2C07608BC8F6A2923 /* SKCashTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = EBAC7CF928D68AD3EE37FB4D /* SKCashTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BC033CBF12EF5CB38F9FDAFB /* AbstractMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = C55205D98ACA2596E3A93000 /* AbstractMessage.m */; };
-		BC06764A0C9856B8E2BC314D /* PBArray.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A0970111F805282AEC6CAD /* PBArray.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BC4E14FBDCBBB4AA22994DFA /* Message.h in Headers */ = {isa = PBXBuildFile; fileRef = 90BEF1EF981624D8235EE9E6 /* Message.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BC6C3998081CECED8BE5FB98 /* UnknownFieldSet.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DD52DE4A9AAD6E3A69EB894 /* UnknownFieldSet.m */; };
-		BD56D7AF7AA81ED99B3D132F /* NSDictionary+SnapchatKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 1EDA4E519FE1136F8E6159C2 /* NSDictionary+SnapchatKit.m */; };
-		BDA1BB7FE4B35AE0DBE962FD /* MessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 0746351ADCB0B21FE32B2E85 /* MessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BE879F5CEFBE2DBA55CCF4CE /* SKFoundFriend.m in Sources */ = {isa = PBXBuildFile; fileRef = B71A42ED9C9A282E7A4B4542 /* SKFoundFriend.m */; };
-		BEAAADF2611C76AFF198731C /* UnknownFieldSetBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = AAEE9103C8BA8123534B7278 /* UnknownFieldSetBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BEBC9081A0F4D6C954308634 /* TextFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = 502600138FD1162EC5F0E835 /* TextFormat.m */; };
-		BEDD54DDF41F99E89B95CE9B /* SnapchatKit-Constants.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A4E677C0A6B08357EDE38B3 /* SnapchatKit-Constants.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BEF1E497350B92BEBC4EC3A1 /* SKSharedStoryDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 8FD3C16495412F844A298EA3 /* SKSharedStoryDescription.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF289DFD6456CFAE6373C264 /* SKSnap.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E8F65183882F17A3EE5BA5D /* SKSnap.m */; };
-		BFFC774096EB83C9D41F6177 /* Attestation.pb.m in Sources */ = {isa = PBXBuildFile; fileRef = E4C61B7D956E59989273650A /* Attestation.pb.m */; };
-		C01E0429813C870987F1E7D7 /* Utilities.h in Headers */ = {isa = PBXBuildFile; fileRef = B758A255FCB12557BF687DBF /* Utilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C083EF2CA7FE862AB249BBB3 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01A3D282D76F2492158972A9 /* Foundation.framework */; };
-		C0990C4C3544E86079AF338F /* NSData+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 9BE3B4334F276CA5FE417047 /* NSData+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C124B95AFA41E5784D5BA178 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = C90C099E43248D72169A5B0B /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		C1F5A0ECA14A647A3D1DF994 /* MutableField.m in Sources */ = {isa = PBXBuildFile; fileRef = FEAB71425CD10455E6D75F28 /* MutableField.m */; };
-		C2350014B021DA0EB009B556 /* SKUserStory.h in Headers */ = {isa = PBXBuildFile; fileRef = FD60E62E28DCF876A104F0A7 /* SKUserStory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C2C500C4791C90477A06702D /* NSArray+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 5458179AFBA3B4551E76D06C /* NSArray+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C45AFC61433D61E1F3000D4D /* NSDictionary+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A09000891FE155F04E84237 /* NSDictionary+MTLManipulationAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		C471C201C7F4A54FFD9C9172 /* SSZipArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = 9580C868D4BD628B16033847 /* SSZipArchive.m */; };
-		C48C586F1945E55235C497ED /* SKSession.h in Headers */ = {isa = PBXBuildFile; fileRef = 8ADC4AAB6A6ABCE48BCC5F84 /* SKSession.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C60D49ED676F30B7845E2CA9 /* ioapi.c in Sources */ = {isa = PBXBuildFile; fileRef = 0A8FA92E556068A6CE1CCE16 /* ioapi.c */; };
-		C61A080E1DE7872975B4EECF /* ExtendableMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 6070FF02167CEB9FC7458D39 /* ExtendableMessage.m */; };
-		C6540960CCE1833DE9A187E7 /* Mantle.h in Headers */ = {isa = PBXBuildFile; fileRef = E143F32D6FBEF9E2E0AD119E /* Mantle.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C6C4AE550184D5DE8D20EAD3 /* Bootstrap.h in Headers */ = {isa = PBXBuildFile; fileRef = 7183BB0F3292AEE43022E891 /* Bootstrap.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C72B883DF942D09141559E17 /* SKSnapOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = B97745F20B56DFE00D4434D7 /* SKSnapOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C83EAA7B2AF84CA8AFEFE781 /* NSError+MTLModelException.m in Sources */ = {isa = PBXBuildFile; fileRef = EDDC5E23649AF7A1E0BB82E8 /* NSError+MTLModelException.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		C9380CC96C046AF00F72DB1C /* SKStory.m in Sources */ = {isa = PBXBuildFile; fileRef = 346F22DD245A0A72527AE1C8 /* SKStory.m */; };
-		C9A3475A3982D12122BDCAD7 /* SKClient+Chat.m in Sources */ = {isa = PBXBuildFile; fileRef = 31201F9C36DCB8072A773375 /* SKClient+Chat.m */; };
-		CA446899C7BBC77646BD88E1 /* MTLJSONAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = F275805645C8FED83BC58CE7 /* MTLJSONAdapter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		CB09833EAA71D804C66952B6 /* SKThing.h in Headers */ = {isa = PBXBuildFile; fileRef = FF2964E8E281C6629782BFF8 /* SKThing.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CB1994B2052C811C3754538C /* WireFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 91FD8FDCB1EF8E5342243FB7 /* WireFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CB6B7B14A54515F9FDA04CB0 /* ProtocolBuffers.h in Headers */ = {isa = PBXBuildFile; fileRef = 60CD411A1CA63391B2D224AB /* ProtocolBuffers.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CBCEC0BBA7D785AB6BE692B8 /* SSZipArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = 5846DBD972BB2E4E8516487A /* SSZipArchive.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CBFF88392C49F2537FCB39E3 /* SKClient+Device.m in Sources */ = {isa = PBXBuildFile; fileRef = B82E05A3E46B11BD9BF8921D /* SKClient+Device.m */; };
-		CC1368C25F6D4FF233355A99 /* NSObject+MTLComparisonAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = AACC20FB1D0DE81D97FC7F46 /* NSObject+MTLComparisonAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CC33DDDA32C3B6D356876969 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = C90C099E43248D72169A5B0B /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		CC4153A0C7A6823D96718C4C /* GeneratedMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 6532EFC9D4874C91D352A810 /* GeneratedMessage.m */; };
-		CCABC287BF8DF4B9606BCA64 /* SKClient+Discover.m in Sources */ = {isa = PBXBuildFile; fileRef = DCDA93F546D12297EA015005 /* SKClient+Discover.m */; };
-		CD8B85221903AFD0E12CB805 /* NSString+SnapchatKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 74DA603BC9A41DF99F80FF9C /* NSString+SnapchatKit.m */; };
-		CDA097F8DB927993EC8F3C3C /* MTLModel.m in Sources */ = {isa = PBXBuildFile; fileRef = E2FB4A4D3FF57F7B9A0C482C /* MTLModel.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		CDA7DE8C36BBC580A37C677E /* ExtensionRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 1628AB0CEF6EECD372AA222B /* ExtensionRegistry.m */; };
-		CDE96097F3636F13D6B1236D /* ObjectivecDescriptor.pb.h in Headers */ = {isa = PBXBuildFile; fileRef = F9218CE3AF46DF110AC1FC93 /* ObjectivecDescriptor.pb.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CE3F421B122257ECCBC8D585 /* SKNearbyUser.m in Sources */ = {isa = PBXBuildFile; fileRef = DC77D677392F90E40D0F2B2F /* SKNearbyUser.m */; };
-		CEB4C095D7E10C49CCDD568A /* SKRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 87DC6A533A3CB69CFE3FC6D8 /* SKRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CF5059529FDC646C45103006 /* unzip.c in Sources */ = {isa = PBXBuildFile; fileRef = 367E68898317851726B59744 /* unzip.c */; };
-		D0CAA80CCE05545EC3EE81DA /* MutableField.h in Headers */ = {isa = PBXBuildFile; fileRef = B359AC7608C8680235607B64 /* MutableField.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D1223C3FD1E7BCEBAB80391D /* SKClient+Chat.h in Headers */ = {isa = PBXBuildFile; fileRef = F552284B16EA501247330C10 /* SKClient+Chat.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D13B0963192862526CC0B0C6 /* SKClient.h in Headers */ = {isa = PBXBuildFile; fileRef = AD3C9AC8DBADBCAB8DA86DA8 /* SKClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D1F511EDEE113E0451ACA3C2 /* ConcreteExtensionField.m in Sources */ = {isa = PBXBuildFile; fileRef = 7604B3135534C28027647CD5 /* ConcreteExtensionField.m */; };
-		D2A79160613BFAA9D61691EA /* ioapi.c in Sources */ = {isa = PBXBuildFile; fileRef = 0A8FA92E556068A6CE1CCE16 /* ioapi.c */; };
-		D2E7D2147E016EE921F568F7 /* unzip.c in Sources */ = {isa = PBXBuildFile; fileRef = 367E68898317851726B59744 /* unzip.c */; };
-		D338030AB92FEFCA24D0DE4E /* ioapi.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A0021AF19BB03BE8068C892 /* ioapi.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D41FE1FB0E63031E16E8F3D4 /* SKAddedFriend.h in Headers */ = {isa = PBXBuildFile; fileRef = A766840A3FA15875DD115B84 /* SKAddedFriend.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D5550310E4A272DF4108A3A6 /* SKStoryCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F6C4F7854C482C05E42ED2B /* SKStoryCollection.m */; };
-		D66CE564C0C570BD16CF4C43 /* NSDictionary+MTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = D62E5A585E176727B114DBF8 /* NSDictionary+MTLManipulationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D6889A87AC6447CBC7E8F0DA /* Attestation.pb.h in Headers */ = {isa = PBXBuildFile; fileRef = BC234E8391D1425381C05523 /* Attestation.pb.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D6E30A4C3CCF449751087B80 /* Pods-SnapchatKit_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3373DEC2ACD88C7B0D7E398D /* Pods-SnapchatKit_Tests-dummy.m */; };
-		D71DCDE64214FDF0C4F6C386 /* MTLModel+NSCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B58BC08B10D15123B320AFD /* MTLModel+NSCoding.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		D794F004ABA4395C727F6674 /* SKUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B86948413F2BA125B8C7D03 /* SKUser.m */; };
-		D827F8103B4BC91B0C76C384 /* TextFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 3BE6AF84EBA6D92BCE5C7636 /* TextFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D8F2DB01E000B4B44A7DF663 /* NSDictionary+MTLJSONKeyPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 864BFCBBD456ACC6691691E9 /* NSDictionary+MTLJSONKeyPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D94D9CB8C306C01F459791E0 /* SKNewConversation.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FFFD75623FB9218D73DE323 /* SKNewConversation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D98614A336F0F115FFA4E70E /* ExtendableMessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 8F10C5B94F9F3FF19B6B285D /* ExtendableMessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DA569D88C05692114AB9084B /* SKFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CC372A04E32E3B5A10B6683 /* SKFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DB8A0E07D28EA3872B3CF9CC /* SKStoryOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = F9884910EFC1C632C163D4E9 /* SKStoryOptions.m */; };
-		DBE9EABF86018C62F834BA03 /* NSObject+MTLComparisonAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = AACC20FB1D0DE81D97FC7F46 /* NSObject+MTLComparisonAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DC295132D38D674A691ECF9E /* SnapchatKit-Constants.m in Sources */ = {isa = PBXBuildFile; fileRef = 60FCE66689CCF5D0D0C98357 /* SnapchatKit-Constants.m */; };
-		DC3D4FD00673F71DDF6DEE0E /* NSDictionary+MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = E1DC65C5D930DE74DF698A83 /* NSDictionary+MTLJSONKeyPath.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		DC4F9A4C898754729A52C9B2 /* SKStoryOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 1198650DD0951EF6D7936CB7 /* SKStoryOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DCA52ACE15C079DEB170037B /* Message.h in Headers */ = {isa = PBXBuildFile; fileRef = 90BEF1EF981624D8235EE9E6 /* Message.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DD6C1986C06A59F28C7C55D7 /* WireFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = E6DCF7D3DF29FF7F743F3642 /* WireFormat.m */; };
-		DDCB03B0A12A27415C9FBA78 /* EXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C23DFF2F44056D492331988 /* EXTRuntimeExtensions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		DE190A7FE0B2EE61A90EAA2E /* MTLValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7403F5AB3E4BE3F53F76912D /* MTLValueTransformer.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		DEF1B4D594D9C66529840A0B /* SKSnap.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FF03725A1FBD01F3B54D410 /* SKSnap.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DF268188FECF5560184BCD34 /* SKSnapOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 00F7E64375D906AADEEBE012 /* SKSnapOptions.m */; };
-		DF67DACEA7B0F8A2FB599CBE /* SKClient+Device.h in Headers */ = {isa = PBXBuildFile; fileRef = F1DE6FC4BDB289A1735EC820 /* SKClient+Device.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E05190CB533ECBE7031C8180 /* SKStoryNote.m in Sources */ = {isa = PBXBuildFile; fileRef = 445678C61FB42AB9BD4D4D49 /* SKStoryNote.m */; };
-		E063E5BA606B34EA33ED8501 /* unzip.h in Headers */ = {isa = PBXBuildFile; fileRef = 366DC11AD62752B2C3E9393B /* unzip.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E0B0A055F468FF77E7333648 /* SKFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = B3034C9C4729EFDDAF24276C /* SKFilter.m */; };
-		E1514D9F0EA440C86673EC93 /* ioapi.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A0021AF19BB03BE8068C892 /* ioapi.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E1540AD6343234037C030B58 /* SKLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CE06043D4DC81317EE540DE /* SKLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E17BC1EE00EE3402ACFB34FE /* RingBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = AA149B4D211D5124D4002334 /* RingBuffer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E40B40F4CF10DAC6906D3901 /* SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = D3CB8B66AC28E9296B200E45 /* SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E49996EB3A48A189582F9479 /* ExtendableMessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 8F10C5B94F9F3FF19B6B285D /* ExtendableMessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E6384DF4C106A1EFE5936AD4 /* SKStoryOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 1198650DD0951EF6D7936CB7 /* SKStoryOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E6A3509F0C15CC93FA130319 /* Field.h in Headers */ = {isa = PBXBuildFile; fileRef = F347842C5587B36F931554EC /* Field.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E6B9E9636592B354BEB7E0C5 /* Pods-SnapchatKit-OSX-Mantle-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = C91FA387C6BC12DFCEC16B08 /* Pods-SnapchatKit-OSX-Mantle-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E6F61869F8D45E4A234FF58B /* SKFoundFriend.h in Headers */ = {isa = PBXBuildFile; fileRef = 607499C80038757E311F8CA1 /* SKFoundFriend.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E84AC9A52EFC9B6AC7D05864 /* SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = D3CB8B66AC28E9296B200E45 /* SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E872E19204E513117B4B08E4 /* SKStoryNote.m in Sources */ = {isa = PBXBuildFile; fileRef = 445678C61FB42AB9BD4D4D49 /* SKStoryNote.m */; };
-		E92310B6807E95A45893E613 /* ExtendableMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 6070FF02167CEB9FC7458D39 /* ExtendableMessage.m */; };
-		E9C458601CBB443502CAF765 /* NSArray+SnapchatKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 4693BF7FBC62DA24F8CB6153 /* NSArray+SnapchatKit.m */; };
-		EA298192CA481198A90DE826 /* GeneratedMessageBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = A22019B34FF3D28330B16DF5 /* GeneratedMessageBuilder.m */; };
-		EA63B8F4335E98F69602E802 /* SnapchatKit-Constants.m in Sources */ = {isa = PBXBuildFile; fileRef = 60FCE66689CCF5D0D0C98357 /* SnapchatKit-Constants.m */; };
-		EABE383C749FEFD859EA1449 /* ExtensionField.h in Headers */ = {isa = PBXBuildFile; fileRef = 57779D995D4EED4517C14162 /* ExtensionField.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EAC4AB0A8247BE4BD7C28CE5 /* NSArray+SnapchatKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 4693BF7FBC62DA24F8CB6153 /* NSArray+SnapchatKit.m */; };
-		EB1E8E81D94CF057475F014D /* AbstractMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F32C4F587D89334A3BCBE23 /* AbstractMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EB9D58FAFAB393A26C6EC1D9 /* SKStory.m in Sources */ = {isa = PBXBuildFile; fileRef = 346F22DD245A0A72527AE1C8 /* SKStory.m */; };
-		EBC6272FBBFCF159E263B580 /* SKBlob.m in Sources */ = {isa = PBXBuildFile; fileRef = C72DBD7A6DA7655074E62D29 /* SKBlob.m */; };
-		EBFC6FDD5AFEDD3CD75B1B08 /* SKMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = EB8FB810CD3E9AF9303846D2 /* SKMessage.m */; };
-		EC1C0C225A13D62C9165A3E6 /* CodedOutputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 90D507AAE40D2CEED0D36687 /* CodedOutputStream.m */; };
-		EC7EFBA2154031EEB74007F1 /* SKCashTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = 21D7027B0107A87B98B269DD /* SKCashTransaction.m */; };
-		EC9210B13B79A8C30E5C9A67 /* SKClient+Friends.m in Sources */ = {isa = PBXBuildFile; fileRef = A1ACEF81DAC35F3667E86099 /* SKClient+Friends.m */; };
-		EDB1505CE09418B3F692519B /* UnknownFieldSetBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 71577F1A49CF27CC9FA94074 /* UnknownFieldSetBuilder.m */; };
-		EE2113A634FB1D00B3C430DE /* NSDictionary+MTLJSONKeyPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 864BFCBBD456ACC6691691E9 /* NSDictionary+MTLJSONKeyPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EEDC8833C276A27D22CAB5B9 /* mztools.c in Sources */ = {isa = PBXBuildFile; fileRef = 7137BB5CBC818BC0E912BAE8 /* mztools.c */; };
-		EFEAFE3EE64FE7D8AED7D36E /* NSArray+MTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 4762A159FAA8CE845790577D /* NSArray+MTLManipulationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F017F7A5D6EBC6E9C12447E2 /* SKThing.m in Sources */ = {isa = PBXBuildFile; fileRef = 480232BB439E70191B69829A /* SKThing.m */; };
-		F08B7331F6C611CE350E2896 /* SKStoryOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = F9884910EFC1C632C163D4E9 /* SKStoryOptions.m */; };
-		F0BCCFEA8CAA76F12057FB46 /* RingBuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D12E82F0CEA77B8F7DE1F9B /* RingBuffer.m */; };
-		F15F3D33AECBA0423B371DE1 /* NSData+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 9BE3B4334F276CA5FE417047 /* NSData+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F1B3BC44F6A58033263EA0B9 /* UnknownFieldSetBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = AAEE9103C8BA8123534B7278 /* UnknownFieldSetBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F20155CA3D188FB7706A9214 /* SKMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7029FB4531206FAF1E971E /* SKMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F284CF71A009BE358DC2AC64 /* SKUser.h in Headers */ = {isa = PBXBuildFile; fileRef = 5ED60ED9A8DEB4AF13B67CC8 /* SKUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F3471EDD1EC90CC4D1411676 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 825834A937BE3CAE02AB2EB9 /* Cocoa.framework */; };
-		F438C6281FC9950B3070CD4F /* MTLTransformerErrorHandling.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E2EF527D485AA3518965377 /* MTLTransformerErrorHandling.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F47C27AD219414834E3A70C9 /* SKMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7029FB4531206FAF1E971E /* SKMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F496F281029507E98B199D3C /* unzip.h in Headers */ = {isa = PBXBuildFile; fileRef = 366DC11AD62752B2C3E9393B /* unzip.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F4994BF7DD20E029DDDC0F48 /* crypt.h in Headers */ = {isa = PBXBuildFile; fileRef = 34BDFDCAB53D1C3DF3D8B643 /* crypt.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F4CA0FCE7713A68EC29CDF10 /* ioapi.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A0021AF19BB03BE8068C892 /* ioapi.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F51C21345F82495EE745B0D6 /* EXTScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D4A7091C6DE37C14EBE847D /* EXTScope.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		F5F4A19800FECE5199FE2942 /* NSArray+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 5458179AFBA3B4551E76D06C /* NSArray+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F749139596CF9D5F6CCBE6C1 /* Attestation.pb.h in Headers */ = {isa = PBXBuildFile; fileRef = BC234E8391D1425381C05523 /* Attestation.pb.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F77E198A0817B517E733DE6C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01A3D282D76F2492158972A9 /* Foundation.framework */; };
-		F7C3DED1FC494C7C2E0EC3D5 /* Pods-SnapchatKit-OSX-SnapchatKit-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = E0BE5272169F0ABBBAE1A7C3 /* Pods-SnapchatKit-OSX-SnapchatKit-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F7FE7E5B4B382494C8FF5801 /* SKClient+Stories.m in Sources */ = {isa = PBXBuildFile; fileRef = 17D0AA7AA0EA6CC242B330F9 /* SKClient+Stories.m */; };
-		F82963F146F475AC1334F464 /* Pods-SnapchatKit_Tests-SnapchatKit-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 80B92F86F6383AF6373514DC /* Pods-SnapchatKit_Tests-SnapchatKit-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F838815AA0D9E34FA3551B7A /* NSError+MTLModelException.h in Headers */ = {isa = PBXBuildFile; fileRef = A91683F22FB4EF562527CCF8 /* NSError+MTLModelException.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F905D76F908A1267DEF6D766 /* MTLModel+NSCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = C49BF5D2D648742FCBBC6433 /* MTLModel+NSCoding.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F93144363F17E0D9D34D4F87 /* NSError+MTLModelException.h in Headers */ = {isa = PBXBuildFile; fileRef = A91683F22FB4EF562527CCF8 /* NSError+MTLModelException.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F9EDC541D1A757F6AB8387A4 /* AbstractMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F32C4F587D89334A3BCBE23 /* AbstractMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FA2815AF7F461E02FB242681 /* SKUserStory.m in Sources */ = {isa = PBXBuildFile; fileRef = 90F41EB5F4D4C93EFA06977B /* SKUserStory.m */; };
-		FA4B2D5C3C66E59FEE6A4A4D /* SKClient+Discover.h in Headers */ = {isa = PBXBuildFile; fileRef = FCA6532B428B695F70814807 /* SKClient+Discover.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FA62F1E29E3564025BF7A97A /* SKClient+Account.m in Sources */ = {isa = PBXBuildFile; fileRef = 36ECBA089FD3718EDC1195C0 /* SKClient+Account.m */; };
-		FA83F5BE58CBF6007F5A5572 /* Field.h in Headers */ = {isa = PBXBuildFile; fileRef = F347842C5587B36F931554EC /* Field.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FAC9E343FAA7307CE9512A2A /* SKStoryNote.m in Sources */ = {isa = PBXBuildFile; fileRef = 445678C61FB42AB9BD4D4D49 /* SKStoryNote.m */; };
-		FB706A9DDF2864D39B4CA86D /* SKSnapResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = F128C2CF8C3AF119EF791658 /* SKSnapResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FCFC02D641592E6A98754741 /* MutableExtensionRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D85386BB83B94415BF95032 /* MutableExtensionRegistry.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FD09A9CF8DA29EECDE10A78A /* NSObject+MTLComparisonAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = E3F90C74F6B4513DB6B80D92 /* NSObject+MTLComparisonAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		FD3CCDA4F20913CEDB7D6AAA /* SKAddedFriend.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CB417E7FA3A2177453C0458 /* SKAddedFriend.m */; };
-		FD6098DCD84B7C253763DA2A /* MTLValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7403F5AB3E4BE3F53F76912D /* MTLValueTransformer.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		FD6590AD4CC25A7D2734A10D /* SKNewConversation.m in Sources */ = {isa = PBXBuildFile; fileRef = 150E0D42F8ADD64688F5FF77 /* SKNewConversation.m */; };
-		FE36B81BDFA3AD2CB6AE9675 /* PBArray.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A0970111F805282AEC6CAD /* PBArray.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FE891402D98C4DB033CA60C4 /* SKLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BD6662AFDE6D73BB17E57D0 /* SKLocation.m */; };
-		FEB5BF0A4BC14959C0C3B47A /* SKClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E47188605DEAD31B32CA84A /* SKClient.m */; };
-		FEE8785E94548845BB1857B9 /* MessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 0746351ADCB0B21FE32B2E85 /* MessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FEE928E8D8883C714CBE2194 /* CodedInputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 29CFD017511A61FDEEFEF7FB /* CodedInputStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0053DA2124C8A670D3F7EEF7993E81CD /* MTLModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 35985918E56AD9E0C441B57EF60B263E /* MTLModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		00E35003DE132CA79A526FCE89D77E16 /* RingBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 31F648378E994908BE3DEFFBD2CEB0CB /* RingBuffer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		00F6A1A5886C968EAEF709F025C629BD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46EF97B3320D5567B3CD996D681E6DB9 /* Foundation.framework */; };
+		0120362E8FDC4F1EBE0377D52527161F /* UnknownFieldSet.m in Sources */ = {isa = PBXBuildFile; fileRef = E7FF2C7F1C9F03E9F9FFEEEB71828E5D /* UnknownFieldSet.m */; };
+		019F98F946817BFC8036990FC4866029 /* SKSharedStoryDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 783EA1ECC5FDE5F2CB4C6E1B8B5B9896 /* SKSharedStoryDescription.m */; };
+		01F6E48CB9D03467B4E5E15A86E9E696 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46EF97B3320D5567B3CD996D681E6DB9 /* Foundation.framework */; };
+		023388DFA5754C45B0A6A5C0F26D3077 /* Pods-SnapchatKit-OSX-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 1DC3BE7BB86B644F4B88640AA93A535C /* Pods-SnapchatKit-OSX-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		024CB5A94F8C400B1D9BB8FECD524A98 /* crypt.h in Headers */ = {isa = PBXBuildFile; fileRef = 79F59B49CE4DC99DF440AE4D85E72F6C /* crypt.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		02A7B6428992BB41A044CDFCF0F97B46 /* AbstractMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 07EAD9F6F9FA6CF821F00410E5793C55 /* AbstractMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		042DA1E4404BBD3A35D5275D4A29413A /* SKClient+Account.m in Sources */ = {isa = PBXBuildFile; fileRef = 20F34E602ECE0E9952C0C9CC8D2E971A /* SKClient+Account.m */; };
+		05735D40AC69A1FBBDD5DF622B479835 /* AbstractMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 07EAD9F6F9FA6CF821F00410E5793C55 /* AbstractMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		065BB6D4330B794A98798E58C47C06E9 /* SKSnapOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 102BD1F037C4B0705E82FACAADBC648A /* SKSnapOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		06C96BD41A4B7F0388545998F3943C91 /* SKSnap.m in Sources */ = {isa = PBXBuildFile; fileRef = 802057E388A43AE12453D12948E1951C /* SKSnap.m */; };
+		080A566E7AD4F2B01E74EF2A7DEA64A5 /* MutableField.h in Headers */ = {isa = PBXBuildFile; fileRef = E6B8AC488192EFFE38ABFA7054D5FAE7 /* MutableField.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0896BADCF11D56EFB35F8EBA7AD68059 /* Descriptor.pb.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A58A6FF946BC36ACBE07A96585CF06D /* Descriptor.pb.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		08EB02EB1A0D64F62DF4EFEAC197AE50 /* GeneratedMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 7141EAD9F0391CA0B89AA690FD467035 /* GeneratedMessage.m */; };
+		091822D8E56D1D6FE6840674A4F12ADD /* Mantle.h in Headers */ = {isa = PBXBuildFile; fileRef = 59F7C50BC794CD8AE4A522E621CBDEB2 /* Mantle.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		09475913E1E8F8A5C967C95D101B5748 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0D7CCAAC157EB2E8A7F7A2290A48C89A /* Cocoa.framework */; };
+		0981354675608E7EBD38A6EEBF66B37C /* NSString+SnapchatKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 54460D90C5A5A625598F1A72569A13B5 /* NSString+SnapchatKit.m */; };
+		099696D740CF3C866F1CC938442BFB2D /* SKAddedFriend.h in Headers */ = {isa = PBXBuildFile; fileRef = 65C6A40590103EE3AACC40219CF10B19 /* SKAddedFriend.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		09C58BC21A0FBF1C5429A24448572F2C /* SKClient+Friends.m in Sources */ = {isa = PBXBuildFile; fileRef = A80EB289DF56408DBC3088C043E15245 /* SKClient+Friends.m */; };
+		0B619861F6B430E30337F61DB3F4D4E6 /* ExtendableMessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 151083D0F45656947CF1BAD22F86B9EE /* ExtendableMessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0BB90E81EBAD7A3CC465A757B8380910 /* EXTScope.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D5F2EFE545E38C869A6A2D1EABEFE6F /* EXTScope.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		0BCF2760E68800780670F754593FD6D8 /* WireFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E8F6A76DF1D61C5C7225F9DDCD74CA3 /* WireFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0C76554583B90F6209F6C1C71908B250 /* MutableField.h in Headers */ = {isa = PBXBuildFile; fileRef = E6B8AC488192EFFE38ABFA7054D5FAE7 /* MutableField.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0CC5E979EB52B9966F2B4E18315DBDC0 /* SKRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = E723F5E599FCD85ABFD4F911E3DDDE5F /* SKRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0CF6E8F089E0B74DC3B3895890C8FB64 /* NSError+MTLModelException.m in Sources */ = {isa = PBXBuildFile; fileRef = A3B3600563469E165A512779D2952B19 /* NSError+MTLModelException.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		0F2D519BD6C421E07B3026992381A769 /* PBArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A69F98F1A3DEA5E52B393E4CA8AEAF9 /* PBArray.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1031F9FEA1EDEE8A92E93180AE933A14 /* CodedInputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 04365EC94A261DF5AA309962BFE4E7AA /* CodedInputStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		10426A8D8C4853EB096DF09D705CA7BA /* ExtensionField.h in Headers */ = {isa = PBXBuildFile; fileRef = 01E0A94D80868EC6EA02AE1C229EAC5D /* ExtensionField.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		10A7A4024E814E076590E646FFF0598B /* SKFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 84C3168646A0D3D84DBEAC87C1C0BDA6 /* SKFilter.m */; };
+		10D87EDBD6A461EF900178ACA1418051 /* SKSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 0460FB606CE25E0ACED9CBF453B53217 /* SKSession.m */; };
+		1107E4CBC86BF83F18245209D524D8F5 /* CodedInputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 04365EC94A261DF5AA309962BFE4E7AA /* CodedInputStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		117837E528FF3B6B5031482C70232403 /* SKSnapOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F8EFE9CDCA52EC0CCBD1DF32DA061F4 /* SKSnapOptions.m */; };
+		136C3D9C55DCC9D82F7E5E0159DB7DAE /* SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E8E9BC41A16B11C168D078CD7578264 /* SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		148C3AF9412E237E62890F1304800EAB /* ioapi.c in Sources */ = {isa = PBXBuildFile; fileRef = 4EBD65303E77D9EF88B73826511C216D /* ioapi.c */; };
+		14D34F80BF1B9C568BCB71A93D9ABAF8 /* MutableExtensionRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DD538EFE6D0B801F385F20D93048AED /* MutableExtensionRegistry.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		16B2AA343067DCAD6CD1BED7DBC6287A /* EXTKeyPathCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = F1D1A5B737A29E03602B5C8212455D59 /* EXTKeyPathCoding.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		173F923EC24D6D2DB09D59D434B54C6E /* MessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = E3D463D60137F8318D301057A1ECFDB5 /* MessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		17F5075BD7E38D4E0D1BFE5C19CA3D69 /* SKClient+Snaps.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FEA67B46E224685AD9C805D1A27E5D9 /* SKClient+Snaps.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1841924A876FF2571659ECFD3B1EE210 /* SKSnapOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 102BD1F037C4B0705E82FACAADBC648A /* SKSnapOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		185E6B9D1562C1D1E1A49B73FC1FF46F /* SKStoryNote.m in Sources */ = {isa = PBXBuildFile; fileRef = E7264B33B0A0713CE212280490FD1800 /* SKStoryNote.m */; };
+		185F49393199308807E43E7F2987BF93 /* SKBlob.m in Sources */ = {isa = PBXBuildFile; fileRef = EC153DEC3715CFBB867734E4DCF5C9D6 /* SKBlob.m */; };
+		1A5975CE8C5E0498D886DEB4452CEEFD /* Utilities.m in Sources */ = {isa = PBXBuildFile; fileRef = E059AC38BADB0D1B36F1843E1BE50C2F /* Utilities.m */; };
+		1A704361620477DAB19E6EBD967D8F24 /* SKFoundFriend.h in Headers */ = {isa = PBXBuildFile; fileRef = 93D7F125345B7EE254042449068E0D63 /* SKFoundFriend.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1B076DF3B4692E545CA4410C3A0B9E70 /* EXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = C994D8C3A0E2BD2F6A50788977A698B4 /* EXTRuntimeExtensions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		1C3E25E616DC7ACDA6A71318B5B97A0B /* SKConversation.m in Sources */ = {isa = PBXBuildFile; fileRef = 979970EC473F3B7EC64A997D0DAB7410 /* SKConversation.m */; };
+		1CCCE7272B85A744EA4BBFF2A2B1A584 /* SKStory.h in Headers */ = {isa = PBXBuildFile; fileRef = B4B133121782FD34737B816B9476DBF9 /* SKStory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1EB2D4070BDBA437257948E9847CAD45 /* Pods-SnapchatKit_Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = ED040AD1A09159B67F92E0C54034D46E /* Pods-SnapchatKit_Tests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1EBB70A8E528040C3B96E6616F4ACEA2 /* Attestation.pb.m in Sources */ = {isa = PBXBuildFile; fileRef = 606FE432D85DF39B09C3DE7E82B31AD7 /* Attestation.pb.m */; };
+		1ED98A92A15D6CFBACA73E27FA44A2EF /* GeneratedMessageBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 463D5934C525845DDF6D4108DF174801 /* GeneratedMessageBuilder.m */; };
+		1FB6E89D3C3C052571A2F83067A66C7F /* SKStoryOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = C889F248D1DED2AFD880A16BC306586F /* SKStoryOptions.m */; };
+		20BF5F6B9510180FBCB8678A9D06FBC1 /* SKCashTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A0F9C65CF3106FAC238CDC512FF51E2 /* SKCashTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		21FA76F5E9B6056E3125903D3DD6C607 /* SKStoryCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D74C791C2358D9D5C3D0605B6C1FE5A /* SKStoryCollection.m */; };
+		2220D5B5B8CD3829AC386924E7077832 /* Descriptor.pb.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A58A6FF946BC36ACBE07A96585CF06D /* Descriptor.pb.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2264E1B7537847FB1E24B6EEE74ED9E3 /* Pods-SnapchatKit_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A5B71C481C0DEFF98AA08BF9328DB8C /* Pods-SnapchatKit_Example-dummy.m */; };
+		2374F497E8C89CB6D8C49233C14F4DC9 /* NSError+MTLModelException.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A4992617DD257BF87C19BD4E5A7D2A9 /* NSError+MTLModelException.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		237F5429A90C1C3874380DFCC7F50349 /* SKSimpleUser.h in Headers */ = {isa = PBXBuildFile; fileRef = E54E26EDFAA3F10A36830DE50A7A5B14 /* SKSimpleUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		23909EA74D814415AD25CAA0D3429E8A /* NSValueTransformer+MTLInversionAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FDC119599936009F4BBDAE2B034A189 /* NSValueTransformer+MTLInversionAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		242F7528027487EBDCAB8DB71CDBB224 /* SKFoundFriend.m in Sources */ = {isa = PBXBuildFile; fileRef = 31E2210149C81E3944A0BE1276CAC3A1 /* SKFoundFriend.m */; };
+		243D3B86A9A67DEFD0BDCEE4D6C7D839 /* ObjectivecDescriptor.pb.h in Headers */ = {isa = PBXBuildFile; fileRef = CDF8D63AD3F269AECF961EB562B4584D /* ObjectivecDescriptor.pb.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2505947A59E09D87EC189986798356C0 /* SKRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9412679689721ADFAAC7A895E02BA5AE /* SKRequest.m */; };
+		2585D6EA8E5FE203C3FC8CB2FEEDF40A /* zip.h in Headers */ = {isa = PBXBuildFile; fileRef = FB2D208BA9563060C0278C6D8F71C479 /* zip.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25AE841809F8AB20D9F55F85861DA349 /* MessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = E3D463D60137F8318D301057A1ECFDB5 /* MessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		26011E3D61F619D4A9BCEC383FEAC05D /* MTLJSONAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D6DA22E10B78E607B571F2A55C30EF9 /* MTLJSONAdapter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		267CF5C3C42266B456D26CCB8A6AF099 /* SnapchatKit-Constants.h in Headers */ = {isa = PBXBuildFile; fileRef = CE4ABDF04FF8494E1C5D6E053D288B2A /* SnapchatKit-Constants.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2681E46DD69A2B7004A58ADC8E080957 /* CodedOutputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = C166F11F874CC66F155035BD723C973A /* CodedOutputStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		268F4A06D7E5CF71356647535F47A0F0 /* ExtensionRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 37186F3BDEF4361A87EE611FE929CFB9 /* ExtensionRegistry.m */; };
+		26A8FB84B0F7ACB0C5403E4A920A0881 /* SKClient+Device.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E8C22914F0D53BA79853BCCAE38D6A0 /* SKClient+Device.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		282B53B2BA402322977754FB8714551A /* Mantle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73839BEC40DA572D986E82BD377F57E7 /* Mantle.framework */; };
+		285286FE8C7219404AE1AA0A97E12410 /* MTLReflection.h in Headers */ = {isa = PBXBuildFile; fileRef = 14DA7638F179D4435E88DD761A6C54AF /* MTLReflection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		285A44F32981BF111E7B69389A567FBC /* UnknownFieldSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FDCF9C141D2B76551E065804EB72AF7 /* UnknownFieldSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		28DF9E35FEEF371076C9AABB943FC426 /* SKRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9412679689721ADFAAC7A895E02BA5AE /* SKRequest.m */; };
+		28EFD06561A33BB46DC2F345BAE48F00 /* SKBlob.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C6AC9F19531D3677DC1E1AA6B8FB54C /* SKBlob.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		291074E3CE3F4E7C5A5B24788B18FDB4 /* Pods-SnapchatKit_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 5EB492FF04D6F8DCD3DC8589194EEE5B /* Pods-SnapchatKit_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		29A9097F89096BE5EBDCE09AACEDB4DF /* SKClient+Stories.h in Headers */ = {isa = PBXBuildFile; fileRef = CEB772F1CD2E64A93211D413F991E158 /* SKClient+Stories.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2A3FD722D66554C3FD99A077BE65D6B7 /* TextFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = D7120C8C40EF2A6454683D2023AA4521 /* TextFormat.m */; };
+		2A4815BAB2A6E3324A82C79821FC20FA /* SKClient+Snaps.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B86B77A0AE12A3715630EF1051CE196 /* SKClient+Snaps.m */; };
+		2AAB06CEF6C7D4BBB7D06BD2993EF2D1 /* GeneratedMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = B3547AAE494746F0CF2277659F9390E4 /* GeneratedMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2B0F64923471BA3F63DC781C394ADEC0 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0D7CCAAC157EB2E8A7F7A2290A48C89A /* Cocoa.framework */; };
+		2B239733EFEB61D079A67020119FCFAD /* SKStoryUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = 34D90DB5D3A0F6C9F52829680C3A220D /* SKStoryUpdater.m */; };
+		2B6A2EAC3A16273CB0DDDF31C678D2AA /* SKThing.h in Headers */ = {isa = PBXBuildFile; fileRef = E9AF192BD8DD526AEB6FD5A02EEB2A56 /* SKThing.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2BAF5FD6442AAAFA815184C991BF5981 /* SKSession.h in Headers */ = {isa = PBXBuildFile; fileRef = AA054E5F64577F7C772D73102EF8F7C1 /* SKSession.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2C36FC399C44B70FA6EB83E7FE3B585D /* ConcreteExtensionField.h in Headers */ = {isa = PBXBuildFile; fileRef = 6826B1CCA448E90716D8C1B6E74BC68B /* ConcreteExtensionField.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2C5E77D721BF52522874B95F79773870 /* SKMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 0CA59E7E475EC4C780AB17196EE1F175 /* SKMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2D46D77583FA1839F8F18AC7F2D9B69E /* SKClient+Friends.m in Sources */ = {isa = PBXBuildFile; fileRef = A80EB289DF56408DBC3088C043E15245 /* SKClient+Friends.m */; };
+		2D7E75274682CC83AA1FDCB1BDDDB3C3 /* SKStoryUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = 34D90DB5D3A0F6C9F52829680C3A220D /* SKStoryUpdater.m */; };
+		2E044016AC68BA7C627FF8D226501E9C /* NSDictionary+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 523519361513D98C2F08E815B11DEF1B /* NSDictionary+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2E159F707367B81C694A7E642EF8E9B8 /* SSZipArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = 0595D336EA25C014342530119C843CA6 /* SSZipArchive.m */; };
+		2E38B3A0594877C7393F558A96FF21EE /* NSDictionary+MTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = DF085137EB0F35B5B37260EABF2BC4FF /* NSDictionary+MTLManipulationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2F2DBCB99EFB00EC2A9965B8FBB8E91A /* UnknownFieldSetBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 15787D58A018F7C163848E0EDEFFF2AB /* UnknownFieldSetBuilder.m */; };
+		305CEBA9E37E583C6CC9F26CED58F86D /* RingBuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = D7AD70060269B4629B407FE76BD9B976 /* RingBuffer.m */; };
+		31A006C7D74D36E484C66524FB9B94E2 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0D7CCAAC157EB2E8A7F7A2290A48C89A /* Cocoa.framework */; };
+		31E7338BAEC9D179702663B3590EFBC2 /* EXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 747032A30F0B0CFAE55E25EE38C28805 /* EXTRuntimeExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		31F9DB362566BA94B17E3D7ACB3D3E0C /* SKSnapResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = DD4D2DD38DC19BF04525CD76056DF23B /* SKSnapResponse.m */; };
+		32562F5973360621D7CA56CDF47BBCBD /* NSDictionary+MTLMappingAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = DCD2256F10F763F211E4C0CA353ABC10 /* NSDictionary+MTLMappingAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		327FB4E32BA8FA11A5AA93494478E623 /* TextFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 70A50AB4E7409F7A938AA8915CE5522B /* TextFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		333746533E88A8D63428AAB777A2EDE8 /* zip.c in Sources */ = {isa = PBXBuildFile; fileRef = 4F0F9FF93E2C703E32F8511026F85347 /* zip.c */; };
+		33652DC56E0E09225FB68B91D2FC9618 /* EXTScope.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D5F2EFE545E38C869A6A2D1EABEFE6F /* EXTScope.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		33D957620493F21F222B84BA21230B19 /* SKSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 0460FB606CE25E0ACED9CBF453B53217 /* SKSession.m */; };
+		34140D666739EE70A5CC09E86EA7F79A /* SKClient+Stories.h in Headers */ = {isa = PBXBuildFile; fileRef = CEB772F1CD2E64A93211D413F991E158 /* SKClient+Stories.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3478C6911235F8AD6BA9C548001FF475 /* SKMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 5532B761F50A991D01D8E66810F650B5 /* SKMessage.m */; };
+		34E59F617948E6EEEEC2B2D129564333 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46EF97B3320D5567B3CD996D681E6DB9 /* Foundation.framework */; };
+		3511A586469839753FD18D25F2674AC2 /* TextFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = D7120C8C40EF2A6454683D2023AA4521 /* TextFormat.m */; };
+		35497EE619866A2A4DF2311997211129 /* SKClient.h in Headers */ = {isa = PBXBuildFile; fileRef = DE3FD306D6487F5A6E0F63B0BA4493A1 /* SKClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		35D830851654D766CF88256978A23C1F /* Utilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FADA08C22B41CD08228C4250C6B1A70 /* Utilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		362581EBF1FCC3D1700D1848419B712B /* ExtendableMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = D13B01407D9005CF9C5677552DCDC6A1 /* ExtendableMessage.m */; };
+		367747D40D02006C7203A8FE9D8B4EF1 /* CodedInputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = D64A94D4DFB38E5653DD76D20218BE09 /* CodedInputStream.m */; };
+		375918802120B79CE1A811521FF565C3 /* Descriptor.pb.m in Sources */ = {isa = PBXBuildFile; fileRef = 55BA9EA15DD7130BEC47C5B99EC9384A /* Descriptor.pb.m */; };
+		377B4976BE7CFD109B545F252618C439 /* SKStory.m in Sources */ = {isa = PBXBuildFile; fileRef = 9269F78B7355A85A30F6036EEAAC51C9 /* SKStory.m */; };
+		383508FE12C8DCCB754440DC8687ED7A /* SKSession.h in Headers */ = {isa = PBXBuildFile; fileRef = AA054E5F64577F7C772D73102EF8F7C1 /* SKSession.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		39BA0E82CE3772CCB25D8794CB97340D /* SKClient+Account.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CBC1007B50FB6D8D8CCC49C9AA3A908 /* SKClient+Account.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		39EA28C03534E3CF349C04D02204C43F /* Bootstrap.h in Headers */ = {isa = PBXBuildFile; fileRef = 30F3816561C0672DD603262F36C61EB4 /* Bootstrap.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3A3C6B40096B06D7E7A863D6B449807A /* MTLTransformerErrorHandling.m in Sources */ = {isa = PBXBuildFile; fileRef = B0B3A02E4506C7059D914FEF250427E1 /* MTLTransformerErrorHandling.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		3A6FC738621BE4B504C4A4FF9CECDF37 /* MTLTransformerErrorHandling.h in Headers */ = {isa = PBXBuildFile; fileRef = C93DEA42EF984A92E5FFF4F5EA4C4576 /* MTLTransformerErrorHandling.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3A756AB0B3037F170DBDF16A0B91DFFF /* SKClient+Chat.m in Sources */ = {isa = PBXBuildFile; fileRef = 23C622E56337996E2A8713254F5BD246 /* SKClient+Chat.m */; };
+		3A78EF3DCDA40F259FFC98CAFC79D2ED /* MTLReflection.h in Headers */ = {isa = PBXBuildFile; fileRef = 14DA7638F179D4435E88DD761A6C54AF /* MTLReflection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3B2953BAC27BEA23E001EA38A96EDD85 /* ConcreteExtensionField.m in Sources */ = {isa = PBXBuildFile; fileRef = 7451E9844399D33B0EF8F081DEE45BB9 /* ConcreteExtensionField.m */; };
+		3B4115980D5C8369C944342752FC0C64 /* SKUserStory.h in Headers */ = {isa = PBXBuildFile; fileRef = C24C62067E53B9DD2EB633790E6EECEA /* SKUserStory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3B6759AA51ECB4A6563506707FE654FA /* NSDictionary+MTLMappingAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = DCD2256F10F763F211E4C0CA353ABC10 /* NSDictionary+MTLMappingAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3BB491836714DEA80919FA7F4CBB3586 /* SKStoryCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = 45A8B9B178D3D50255BED3D0FCB98A78 /* SKStoryCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3BCEE80E6BC7E6310081231A8F46E468 /* SKFoundFriend.m in Sources */ = {isa = PBXBuildFile; fileRef = 31E2210149C81E3944A0BE1276CAC3A1 /* SKFoundFriend.m */; };
+		3C35A212B467A3395A6925E546D113BE /* ExtendableMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = D13B01407D9005CF9C5677552DCDC6A1 /* ExtendableMessage.m */; };
+		3CB7CF2F1075ADA90CB8E5C99602CC79 /* RingBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 31F648378E994908BE3DEFFBD2CEB0CB /* RingBuffer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3D3F06AB744A95368C463750E4B80D62 /* NSString+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 01D3D233D27189A14C4D48B64946BEDC /* NSString+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3D4B72F09A7D1AF5AC53C83EB21EC908 /* MutableField.m in Sources */ = {isa = PBXBuildFile; fileRef = 709485E58BF2FF0A4C686203BE95E8EB /* MutableField.m */; };
+		3D5C7C244711B6322687777E61E19A6C /* NSDictionary+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B9085E7485D99346EF2A43B26F8F498 /* NSDictionary+MTLManipulationAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		3DAB7FA1643B395E29020DF3DB043FB4 /* SKStoryOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2349A4CD323EDCB9F3445312B2F9489A /* SKStoryOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3DC3166DBA145A9B1A72D3D0E833404D /* MTLValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 18B61B312FEA02DCE16514E7C4A29FBA /* MTLValueTransformer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3E29BB9178E4EDFADCF80C9CD5AD83DD /* NSArray+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 444ABAE227428925EDF5D132A91868E4 /* NSArray+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3E60CF911969ABE43EC3DCA7D33EC161 /* SKBlob.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C6AC9F19531D3677DC1E1AA6B8FB54C /* SKBlob.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3E7A470C6E7EE8CD1C53D90579C63E24 /* EXTScope.h in Headers */ = {isa = PBXBuildFile; fileRef = B9231F31123010FDAB359C1EE6306140 /* EXTScope.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3F894393B28EA3C7C553B89DDADD20B6 /* SKNearbyUser.h in Headers */ = {isa = PBXBuildFile; fileRef = AF2BABB30D0A63B528450704A8CC4831 /* SKNearbyUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3FEC5DD2C9E80A768FA80341297A41EE /* NSDictionary+MTLMappingAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = DCD2256F10F763F211E4C0CA353ABC10 /* NSDictionary+MTLMappingAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3FF7C22D30BB92DD66F5708F9FB17399 /* SKUserStory.m in Sources */ = {isa = PBXBuildFile; fileRef = EBF31098D1B73D4027EF54C1B7EC55E7 /* SKUserStory.m */; };
+		403C79DF12E4C2526C9C744766D08957 /* TextFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 70A50AB4E7409F7A938AA8915CE5522B /* TextFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		40C077799222167288A2ABC1F56CAF16 /* EXTScope.h in Headers */ = {isa = PBXBuildFile; fileRef = B9231F31123010FDAB359C1EE6306140 /* EXTScope.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4220F732A0E16D07C76BF122C5A883DF /* SKFoundFriend.m in Sources */ = {isa = PBXBuildFile; fileRef = 31E2210149C81E3944A0BE1276CAC3A1 /* SKFoundFriend.m */; };
+		445F6FE8D9561E076CAFD7F720282A17 /* RingBuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = D7AD70060269B4629B407FE76BD9B976 /* RingBuffer.m */; };
+		44F3B511C9F401D8C16800584A31E61B /* SKClient.h in Headers */ = {isa = PBXBuildFile; fileRef = DE3FD306D6487F5A6E0F63B0BA4493A1 /* SKClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		45D38CB575713150B3A90D9D38ABD156 /* SKStoryCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D74C791C2358D9D5C3D0605B6C1FE5A /* SKStoryCollection.m */; };
+		46204E30E187CD54D9E99E2FAA750AE0 /* MTLModel+NSCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 06373D743A4B8735559065DB34A4D3CF /* MTLModel+NSCoding.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		46250D8FE675647F879F57FA4B5C30A9 /* Utilities.m in Sources */ = {isa = PBXBuildFile; fileRef = E059AC38BADB0D1B36F1843E1BE50C2F /* Utilities.m */; };
+		471BC7DC8B0FABD32EAF770E8D686EB6 /* MTLJSONAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B78B5F838295F2C6CCA0316BE4A7C97 /* MTLJSONAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		473B0B374FDCED388C3F0E90450D56FA /* SKStory.h in Headers */ = {isa = PBXBuildFile; fileRef = B4B133121782FD34737B816B9476DBF9 /* SKStory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		478331EF4720256BB0BE0CC2A960105C /* MutableExtensionRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DD538EFE6D0B801F385F20D93048AED /* MutableExtensionRegistry.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		479198E6D223F3F7172CE0402F5E2ED2 /* MTLModel+NSCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 06373D743A4B8735559065DB34A4D3CF /* MTLModel+NSCoding.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		486F8E44328E05773A32FABF6363785A /* SKNearbyUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 4825B54E2CDC5AA561EF544825F2A14F /* SKNearbyUser.m */; };
+		4895A72C93179952912E89C31138CEE7 /* WireFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = 4687F307C6DF4771125FACD4FEF41B6F /* WireFormat.m */; };
+		48D9F27D1DF186EEC82DC1323FBDC8BC /* NSValueTransformer+MTLPredefinedTransformerAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = FB0E1FAC0060ECAB08CEE29646BFE32A /* NSValueTransformer+MTLPredefinedTransformerAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		49158774B3216C2C8D3D59F20541A290 /* ProtocolBuffers.h in Headers */ = {isa = PBXBuildFile; fileRef = 5ACEF1C64263788DDF0A871B5FD3415D /* ProtocolBuffers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4964637AC990C2E5B62511EA4E609D4D /* NSArray+SnapchatKit.m in Sources */ = {isa = PBXBuildFile; fileRef = F20808D5847A1BE5576F1E97363F4126 /* NSArray+SnapchatKit.m */; };
+		49A4D5AABC8F459CEA366B311579E804 /* GeneratedMessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 6192CF7FB23184D714C51581F7A1A1BE /* GeneratedMessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		49F1F759E3211F99AE1EB258A0539A3E /* MTLTransformerErrorHandling.m in Sources */ = {isa = PBXBuildFile; fileRef = B0B3A02E4506C7059D914FEF250427E1 /* MTLTransformerErrorHandling.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		4A4D4EC9627FE511EFBA1983DCA59BBD /* SKClient+Discover.m in Sources */ = {isa = PBXBuildFile; fileRef = 3483A1EC7B5CF9FAD309261F6519CDF3 /* SKClient+Discover.m */; };
+		4AAA0EB9ECD70B397C419509638498B7 /* SKMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 5532B761F50A991D01D8E66810F650B5 /* SKMessage.m */; };
+		4AD59595C51B3FC7C7469B926AB0EED5 /* NSValueTransformer+MTLInversionAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 58BA9F3FC2DC449A0D601CAFBB661733 /* NSValueTransformer+MTLInversionAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4B1709653D0D99E75F38F9F42FF0933D /* SKUser.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DA60CBC900C38B9E72F99E56E639C3E /* SKUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4B394B884B725511E15770EECFE7A593 /* SKConversation.h in Headers */ = {isa = PBXBuildFile; fileRef = FEBB2E828CE404D19FE3169CB4CE45B6 /* SKConversation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4B437DA6250F337A5596D4719DBAA722 /* ExtensionField.h in Headers */ = {isa = PBXBuildFile; fileRef = 01E0A94D80868EC6EA02AE1C229EAC5D /* ExtensionField.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4B738E80961B996C8537CB3576F3770C /* Field.h in Headers */ = {isa = PBXBuildFile; fileRef = AEA4DB5D58231D27AC6CDE90D7240533 /* Field.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4B7A423CFE94D79D0D1602FA8F3541C2 /* SKStoryUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = 774C527EA09A09E0D8CD014D643D2268 /* SKStoryUpdater.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4C18FFE6F916886595FDDFA4893EC18D /* SKMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 5532B761F50A991D01D8E66810F650B5 /* SKMessage.m */; };
+		4C25AFBB79C3C2F852F1C3F28A9C503C /* MutableExtensionRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 39300C3939F3E500421A1E0654225D36 /* MutableExtensionRegistry.m */; };
+		4C9D37555F78D0BB3F541E6DF9A26639 /* NSDictionary+MTLMappingAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 53DAF85FA8CA77FA6432DD4E4865FA28 /* NSDictionary+MTLMappingAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		4D082797F8372F97CE32A2348F67FBD1 /* EXTKeyPathCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = F1D1A5B737A29E03602B5C8212455D59 /* EXTKeyPathCoding.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4D444B31D12FFC10F880F22B7BE29EC3 /* MTLJSONAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D6DA22E10B78E607B571F2A55C30EF9 /* MTLJSONAdapter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		4D70F3802FFF174C2CD5354237570CB6 /* NSData+SnapchatKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AC6595E4B0F1881632644CBC0879775 /* NSData+SnapchatKit.m */; };
+		4E92A504E5A73DF5D5F8FECEFD6E6F9D /* Message.h in Headers */ = {isa = PBXBuildFile; fileRef = B7ABCBE17F86FB9BEECA8062A041C9AC /* Message.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4EB68C418B69373E07B3B1E76E4361FD /* unzip.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FE550472E08ABD8D5B741D1077F61BA /* unzip.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4EC0C4AB25A9E263DDD76006DC34FE1A /* SKSimpleUser.m in Sources */ = {isa = PBXBuildFile; fileRef = C2CC45708F858B3A21FA14F2C3AE0C49 /* SKSimpleUser.m */; };
+		500930FB6D697F545409818C0A93179B /* NSArray+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = B29E8F6A2790D070998F9CF5CF7EE4D1 /* NSArray+MTLManipulationAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		50915B525DD3E78E926D1A1AC5F72B09 /* NSError+MTLModelException.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A4992617DD257BF87C19BD4E5A7D2A9 /* NSError+MTLModelException.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		516823A4FA02BBC792E37395AD1B85DB /* MTLModel+NSCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 06373D743A4B8735559065DB34A4D3CF /* MTLModel+NSCoding.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		527E54842FB111C7860FFB9DF6FB9480 /* SKUser.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DA60CBC900C38B9E72F99E56E639C3E /* SKUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		53C8EBF58BACE87EA90FA1EA39E6ADBD /* SKThing.m in Sources */ = {isa = PBXBuildFile; fileRef = 9172B364044C193573346831B47E3C32 /* SKThing.m */; };
+		54F2E6E1B8A6294B557119AAC804BBA8 /* zip.h in Headers */ = {isa = PBXBuildFile; fileRef = FB2D208BA9563060C0278C6D8F71C479 /* zip.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		556B00BE2A14A7581F617394609E7F06 /* MutableExtensionRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 39300C3939F3E500421A1E0654225D36 /* MutableExtensionRegistry.m */; };
+		55DEE1A5E27B40C5DA252D92BFB01ACC /* Mantle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73839BEC40DA572D986E82BD377F57E7 /* Mantle.framework */; };
+		55ECDA2A000835ADC3D1CFFC8B1AA105 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46EF97B3320D5567B3CD996D681E6DB9 /* Foundation.framework */; };
+		56FD99CC921A36F3CBC643B498364D87 /* SKClient+Discover.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B6CEADD2D0C33311B5DF1F367E954A5 /* SKClient+Discover.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		57350D4D2FBA84A8EF0A057F18C028E2 /* ExtendableMessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 151083D0F45656947CF1BAD22F86B9EE /* ExtendableMessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		575DF65CEF9F1034EA84C3BCFB460C25 /* SKNewConversation.m in Sources */ = {isa = PBXBuildFile; fileRef = E6543108894562824171DF82C827C732 /* SKNewConversation.m */; };
+		58195726FB28C876AA88993C0608A124 /* PBArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A69F98F1A3DEA5E52B393E4CA8AEAF9 /* PBArray.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		59445FD23AD929AD67914FFB3C7520F4 /* SKUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 5515DC27DAB5541F75B0AA3425061AAE /* SKUser.m */; };
+		59D16357DA752F9CFC22A28282493B48 /* ProtocolBuffers.h in Headers */ = {isa = PBXBuildFile; fileRef = 5ACEF1C64263788DDF0A871B5FD3415D /* ProtocolBuffers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5A1C61619D279CD483BDD48CFFD7BAAD /* SKStoryUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = 34D90DB5D3A0F6C9F52829680C3A220D /* SKStoryUpdater.m */; };
+		5A4FCB51BD6040760589B70D51EA7F6A /* UnknownFieldSetBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 15787D58A018F7C163848E0EDEFFF2AB /* UnknownFieldSetBuilder.m */; };
+		5AA3C1936A3820D8E9BC1D8FE05DE37A /* AbstractMessageBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = C1F491F9A8489CC37E4E1795E1924489 /* AbstractMessageBuilder.m */; };
+		5AE8A38561CDA0A9351FFAC780B75A01 /* ExtensionRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 06B966634B688674E5961D625443E7E4 /* ExtensionRegistry.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5BC30758F4D0C0F36B721AE29E3A8C1E /* SKNewConversation.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A537E793DA2330169541319E2AD1A2A /* SKNewConversation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5BF56770C12DFAE89B57DA8727C62793 /* SKBlob.m in Sources */ = {isa = PBXBuildFile; fileRef = EC153DEC3715CFBB867734E4DCF5C9D6 /* SKBlob.m */; };
+		5C29A130746FB6D5E84BDBBBF3959E8F /* AbstractMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 07EAD9F6F9FA6CF821F00410E5793C55 /* AbstractMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5D38AF3FABF526BFA17067B74A14097F /* SKCashTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = F33789AB1CD889C76EE417221D59C3D9 /* SKCashTransaction.m */; };
+		5DB01101ED96777BD84AB8AACEB7A6BB /* SKClient+Snaps.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B86B77A0AE12A3715630EF1051CE196 /* SKClient+Snaps.m */; };
+		5E7EEF8C703DE01F17614CEA0F2BC834 /* Utilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FADA08C22B41CD08228C4250C6B1A70 /* Utilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5E97AAF2BEE6EBD3FF036F96E52E0161 /* SKConversation.h in Headers */ = {isa = PBXBuildFile; fileRef = FEBB2E828CE404D19FE3169CB4CE45B6 /* SKConversation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5EE6F04CE8A0187799937EBBF2126350 /* EXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 747032A30F0B0CFAE55E25EE38C28805 /* EXTRuntimeExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5F596EC498A574B734DAC74A2F5B40CB /* SKClient+Account.m in Sources */ = {isa = PBXBuildFile; fileRef = 20F34E602ECE0E9952C0C9CC8D2E971A /* SKClient+Account.m */; };
+		5F6B760329332CC1E215AD30A4471714 /* SKBlob.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C6AC9F19531D3677DC1E1AA6B8FB54C /* SKBlob.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5F84E4E611C94A8833A393198E0C439C /* MTLModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 21A864CDFDE11D41869495F647850956 /* MTLModel.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		601840AF945E6DAD9409D9F4AC0F84D2 /* Bootstrap.h in Headers */ = {isa = PBXBuildFile; fileRef = 30F3816561C0672DD603262F36C61EB4 /* Bootstrap.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		63912A16DF657113B7EDADE0FC3FA65B /* ExtendableMessageBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D2C9634F9F032DDCBE25B9910E30A5A /* ExtendableMessageBuilder.m */; };
+		6563A9DA69FA273918AE1C64F500EACB /* SKSimpleUser.h in Headers */ = {isa = PBXBuildFile; fileRef = E54E26EDFAA3F10A36830DE50A7A5B14 /* SKSimpleUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		65B5A153711F61BF0D37FC0DD0C36E07 /* Descriptor.pb.m in Sources */ = {isa = PBXBuildFile; fileRef = 55BA9EA15DD7130BEC47C5B99EC9384A /* Descriptor.pb.m */; };
+		65C3BB92487BB24C522222F5FA511BD8 /* NSValueTransformer+MTLPredefinedTransformerAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = FB0E1FAC0060ECAB08CEE29646BFE32A /* NSValueTransformer+MTLPredefinedTransformerAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		65FC258BEA145736F4CB9C917DCC5DFC /* SKSharedStoryDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 783EA1ECC5FDE5F2CB4C6E1B8B5B9896 /* SKSharedStoryDescription.m */; };
+		67406B8865F4919851BAC6BEA7A0B167 /* CodedOutputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = C166F11F874CC66F155035BD723C973A /* CodedOutputStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		675B22E93193447D18446E3DE8E25257 /* AbstractMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E3B442CA4C99021E31A08D4467D4203 /* AbstractMessage.m */; };
+		67EDC13AA60ABBB65208A5082E762C7F /* TextFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 70A50AB4E7409F7A938AA8915CE5522B /* TextFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		686810271159BBFDCF6575E22E786E36 /* Pods-SnapchatKit-OSX-Mantle-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = ADC019666AAF7D7A212B5577793A36B8 /* Pods-SnapchatKit-OSX-Mantle-dummy.m */; };
+		686FF1CB34E4F0795A39A5D74E18077E /* ObjectivecDescriptor.pb.m in Sources */ = {isa = PBXBuildFile; fileRef = 4149CC5EE78E849EAF5DEEFEE5B0AA66 /* ObjectivecDescriptor.pb.m */; };
+		6916DEC99C867F68C2420A0AD0DFA9FA /* SnapchatKit-Constants.h in Headers */ = {isa = PBXBuildFile; fileRef = CE4ABDF04FF8494E1C5D6E053D288B2A /* SnapchatKit-Constants.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6A575A24FA4ABF4977806083C259B579 /* SKSharedStoryDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = E6316AA0C110D87D7C0CEE4F992074FC /* SKSharedStoryDescription.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6ABE31A4D998B09A454798764523FD90 /* ExtensionField.h in Headers */ = {isa = PBXBuildFile; fileRef = 01E0A94D80868EC6EA02AE1C229EAC5D /* ExtensionField.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6B06F02EAB08ABD063C624BC18BA5440 /* AbstractMessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 978BF2612AD5B68A7A65BE361CCDD3DB /* AbstractMessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6B2824B75691F9C3DE9D89565AD14BCB /* SKSimpleUser.m in Sources */ = {isa = PBXBuildFile; fileRef = C2CC45708F858B3A21FA14F2C3AE0C49 /* SKSimpleUser.m */; };
+		6B5ADCF1533B10E43C05B60BC9C49316 /* NSDictionary+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 523519361513D98C2F08E815B11DEF1B /* NSDictionary+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6BA8B54DDCA21FFF73BD889120B17A56 /* MTLJSONAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D6DA22E10B78E607B571F2A55C30EF9 /* MTLJSONAdapter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		6C12BAE728E410C79932652980B431FF /* SKLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 25B50FC7D431013529A4EDF7982F6C0A /* SKLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6CD5886E1C8F03E20962E8E3CBFFFD46 /* NSArray+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = B29E8F6A2790D070998F9CF5CF7EE4D1 /* NSArray+MTLManipulationAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		6CFFFE8D066AC8A212E4332495A030E4 /* SKStoryOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = C889F248D1DED2AFD880A16BC306586F /* SKStoryOptions.m */; };
+		6D0A5F989BECD7803E4C9FCA9E64E663 /* SKStoryUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = 774C527EA09A09E0D8CD014D643D2268 /* SKStoryUpdater.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6D1C5179324E2197B925BE33548A8E0B /* MTLModel+NSCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = D917EDD76808D4D21F22960E1DE309C8 /* MTLModel+NSCoding.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6D69ADC581A6E883B2DFA899DA8723BE /* SKStoryNote.h in Headers */ = {isa = PBXBuildFile; fileRef = 94AE3C50908C86AECCE17C5B46647395 /* SKStoryNote.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6D94E564F4ED8B08C5A4F4044813B8A7 /* MTLReflection.m in Sources */ = {isa = PBXBuildFile; fileRef = 6549D674C4BBFC4AE9F553D4ABED4F95 /* MTLReflection.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		6DC4D8028691675D145D45CA04008AEF /* SKAddedFriend.h in Headers */ = {isa = PBXBuildFile; fileRef = 65C6A40590103EE3AACC40219CF10B19 /* SKAddedFriend.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6DE35003B36618C5EDB05378FD3A3D7E /* SKClient+Chat.h in Headers */ = {isa = PBXBuildFile; fileRef = 97ABC90E3828E9031BC4F158D4F3EEE2 /* SKClient+Chat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6E75134A2ACEC14C584EEE97B258BB55 /* SKSnap.h in Headers */ = {isa = PBXBuildFile; fileRef = 48D10AA8FB91C836871332883EEE8C79 /* SKSnap.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6E8A9BA92639A36DBC0DE93AE0DD78F0 /* NSArray+SnapchatKit.m in Sources */ = {isa = PBXBuildFile; fileRef = F20808D5847A1BE5576F1E97363F4126 /* NSArray+SnapchatKit.m */; };
+		6EEAE3619B32B34D36ED8AA78DB1A0CA /* MTLTransformerErrorHandling.h in Headers */ = {isa = PBXBuildFile; fileRef = C93DEA42EF984A92E5FFF4F5EA4C4576 /* MTLTransformerErrorHandling.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6EF72229A34E368590361CD0ACD79418 /* SKClient+Friends.h in Headers */ = {isa = PBXBuildFile; fileRef = 833D0F7844FB6F9844FF13EF09871134 /* SKClient+Friends.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6FC9297284E6B97475C34E5F64955D1B /* MTLModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 21A864CDFDE11D41869495F647850956 /* MTLModel.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		707CC0B1ABAEC59B775DCB7995E91EB1 /* SKSnapResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FBEB3B3FA6CC7990C60F15777A0090E /* SKSnapResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		70BCAD21362565B8B6FCE6B313D64E2A /* unzip.c in Sources */ = {isa = PBXBuildFile; fileRef = E76B54A5B681A52C9BF1A48F75B3DE3F /* unzip.c */; };
+		713AE4F662C0ABD9A6AB9CCA7E789BC9 /* NSDictionary+MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DF9455276C69ACF288FDCEEB316B212 /* NSDictionary+MTLJSONKeyPath.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		720495FE298D1E150AD5D7841C6CDABB /* Message.h in Headers */ = {isa = PBXBuildFile; fileRef = B7ABCBE17F86FB9BEECA8062A041C9AC /* Message.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		735EC43FFF3F2E70EFAB009963F395E0 /* NSValueTransformer+MTLInversionAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 58BA9F3FC2DC449A0D601CAFBB661733 /* NSValueTransformer+MTLInversionAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		73606C0786F1540F0BA82FBF2174115F /* SKSnap.h in Headers */ = {isa = PBXBuildFile; fileRef = 48D10AA8FB91C836871332883EEE8C79 /* SKSnap.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		74A9C7F9256BE4D04B6BF797A464F16C /* MTLValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 18B61B312FEA02DCE16514E7C4A29FBA /* MTLValueTransformer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		74EEA546A96531BDE2F22FD4495E4AEC /* ioapi.c in Sources */ = {isa = PBXBuildFile; fileRef = 4EBD65303E77D9EF88B73826511C216D /* ioapi.c */; };
+		753F635A30348BC0E506D31883DCE94F /* SKStoryOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = C889F248D1DED2AFD880A16BC306586F /* SKStoryOptions.m */; };
+		755D208883C9A23974BC2A4D501F9627 /* CodedOutputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = C166F11F874CC66F155035BD723C973A /* CodedOutputStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		756522082454C73D6E179A6557165875 /* Pods-SnapchatKit_Example-SnapchatKit-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 980768AD6081A72B8B07BB8294054202 /* Pods-SnapchatKit_Example-SnapchatKit-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		760583C6D0293B56264F7E3A9C8703A3 /* EXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = C994D8C3A0E2BD2F6A50788977A698B4 /* EXTRuntimeExtensions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		7745049219133452DDF043F1335EE362 /* ExtendableMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = D13B01407D9005CF9C5677552DCDC6A1 /* ExtendableMessage.m */; };
+		77750DA27BF7879D82B4EE3D52E43510 /* mztools.h in Headers */ = {isa = PBXBuildFile; fileRef = 1685FA7977E1A72A8CA039CF99A88D23 /* mztools.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7787D715B0932EC381A7A217503C81D3 /* crypt.h in Headers */ = {isa = PBXBuildFile; fileRef = 79F59B49CE4DC99DF440AE4D85E72F6C /* crypt.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		77B17F032EAA511415272130D4FFE432 /* SKLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 25B50FC7D431013529A4EDF7982F6C0A /* SKLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		77EC3AD9A16F93D2A99FA7E24077B4C2 /* NSDictionary+MTLMappingAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 53DAF85FA8CA77FA6432DD4E4865FA28 /* NSDictionary+MTLMappingAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		787F037EADA4F6E7F5441812EB9DB78B /* SKClient+Snaps.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FEA67B46E224685AD9C805D1A27E5D9 /* SKClient+Snaps.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		79969FA9CFC3C2C847770EF64F44D45F /* NSData+SnapchatKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AC6595E4B0F1881632644CBC0879775 /* NSData+SnapchatKit.m */; };
+		79A99170C7433CE688B43AC977697B2C /* NSError+MTLModelException.m in Sources */ = {isa = PBXBuildFile; fileRef = A3B3600563469E165A512779D2952B19 /* NSError+MTLModelException.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		7A26BB491B363D1023D7446361049660 /* Pods-SnapchatKit-OSX-SnapchatKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C1655D290963794DB4DD8A91377BAC2E /* Pods-SnapchatKit-OSX-SnapchatKit-dummy.m */; };
+		7AEFF01882B6D07EA6C6575E714E7ECE /* SKLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 81A6A60094231EA88DCE60750AA13AE1 /* SKLocation.m */; };
+		7AF32F69DFF9CD3A4BDBB7538E278E17 /* unzip.c in Sources */ = {isa = PBXBuildFile; fileRef = E76B54A5B681A52C9BF1A48F75B3DE3F /* unzip.c */; };
+		7B985DA5AD90B39433D3D9A6861B640F /* Pods-SnapchatKit-OSX-Mantle-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 400621EB0B2F9F65897A439566594B63 /* Pods-SnapchatKit-OSX-Mantle-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7BE6E040D3F1AC607295260C3C909DE4 /* Field.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DC6C59C7DEA6461C564B1DA58829542 /* Field.m */; };
+		7C18CDA8B0EBA841F87ABB1611FF8B20 /* ProtocolBuffers.h in Headers */ = {isa = PBXBuildFile; fileRef = 5ACEF1C64263788DDF0A871B5FD3415D /* ProtocolBuffers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7CDB177F22682CBFA481206CADF09D37 /* NSDictionary+MTLMappingAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 53DAF85FA8CA77FA6432DD4E4865FA28 /* NSDictionary+MTLMappingAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		7CEC7865664510578601198B6481E6FA /* Pods-SnapchatKit_Tests-SnapchatKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D5738FF9A898F9686A3AE9C8BF64405A /* Pods-SnapchatKit_Tests-SnapchatKit-dummy.m */; };
+		7D375F95240E56B49AB9246BEBBAAF0A /* SKSnapOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F8EFE9CDCA52EC0CCBD1DF32DA061F4 /* SKSnapOptions.m */; };
+		7D4EE1042363324DF6F26740E061D54E /* mztools.c in Sources */ = {isa = PBXBuildFile; fileRef = 884007D97EAC905D528F2D798D498CA3 /* mztools.c */; };
+		7D91CF1B01A4BE4B453227A680729D21 /* MTLModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 21A864CDFDE11D41869495F647850956 /* MTLModel.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		7D99ECA077EFE880E6E2A0663B9773AD /* NSArray+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 444ABAE227428925EDF5D132A91868E4 /* NSArray+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7DB4E5D0DDEABF686A3A81C9120774AB /* NSArray+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 444ABAE227428925EDF5D132A91868E4 /* NSArray+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7DB7BEADB3E60310D8E4EA2166130CFB /* SKStoryCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = 45A8B9B178D3D50255BED3D0FCB98A78 /* SKStoryCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7DB938DED1829CCFD49CE5C2D25DE3F5 /* ExtendableMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 00655651C6BA81463B1F1AC19D408EFB /* ExtendableMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7DEE744FF90E4E108C01558153BF75FF /* SKStory.h in Headers */ = {isa = PBXBuildFile; fileRef = B4B133121782FD34737B816B9476DBF9 /* SKStory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7E6FC74BD1EA51F8CBFEBD4F1AF2091E /* NSError+MTLModelException.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A4992617DD257BF87C19BD4E5A7D2A9 /* NSError+MTLModelException.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7E899B86BAFA98237D97A32B1BC055BF /* Attestation.pb.m in Sources */ = {isa = PBXBuildFile; fileRef = 606FE432D85DF39B09C3DE7E82B31AD7 /* Attestation.pb.m */; };
+		7EDD03E35763A4701C72D2A61971A11D /* Pods-SnapchatKit-OSX-SnapchatKit-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = D3BD5BF0576E52C406DDEC99C0EBF5B3 /* Pods-SnapchatKit-OSX-SnapchatKit-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		800B2ECD46D46FC159315AF31AF610B8 /* SKSnapResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FBEB3B3FA6CC7990C60F15777A0090E /* SKSnapResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		803F89A1C505A07F75F3306D28C3A5C7 /* MutableField.m in Sources */ = {isa = PBXBuildFile; fileRef = 709485E58BF2FF0A4C686203BE95E8EB /* MutableField.m */; };
+		80AE9C745A522B06E97A31691EBC686D /* SKClient+Discover.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B6CEADD2D0C33311B5DF1F367E954A5 /* SKClient+Discover.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		80C63601371D20829F892DC9CA8CC421 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = A7E0035C4D44DD28CDC29DBEE88C9580 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		80D3C4F20263F275FA6E5D497B2C2978 /* PBArray.m in Sources */ = {isa = PBXBuildFile; fileRef = 80833A66B09D6D42B65135FA200C959A /* PBArray.m */; };
+		80E3A5718419A00654103E2D76C40DC7 /* AbstractMessageBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = C1F491F9A8489CC37E4E1795E1924489 /* AbstractMessageBuilder.m */; };
+		81153517E47875ECCC70490FB290980A /* Message.h in Headers */ = {isa = PBXBuildFile; fileRef = B7ABCBE17F86FB9BEECA8062A041C9AC /* Message.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		815B3644CF9B1A17DF09B89FD4F90AD0 /* SKStory.m in Sources */ = {isa = PBXBuildFile; fileRef = 9269F78B7355A85A30F6036EEAAC51C9 /* SKStory.m */; };
+		818A50C74A4222067AE1AB8D86B9A24A /* SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E8E9BC41A16B11C168D078CD7578264 /* SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		82230F3D2FDC4B015A8164933ABE29EC /* TextFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = D7120C8C40EF2A6454683D2023AA4521 /* TextFormat.m */; };
+		82322A79FF610A7A075BE4404714E3C4 /* MTLModel+NSCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = D917EDD76808D4D21F22960E1DE309C8 /* MTLModel+NSCoding.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		82946214B08EC20BF2FB024EFBF99340 /* NSString+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 01D3D233D27189A14C4D48B64946BEDC /* NSString+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		82C521B31AAC7DFD5D18E618BFBF06CF /* SKClient+Chat.h in Headers */ = {isa = PBXBuildFile; fileRef = 97ABC90E3828E9031BC4F158D4F3EEE2 /* SKClient+Chat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		82D808B2D325BA2A254E565C8F6CC555 /* NSValueTransformer+MTLInversionAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FDC119599936009F4BBDAE2B034A189 /* NSValueTransformer+MTLInversionAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		8329E0046C4D88212E52F57626494008 /* NSObject+MTLComparisonAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 452A825C1C9779653BE134C643213E98 /* NSObject+MTLComparisonAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		8369D6BE3B24E83F01D6B117792A1C68 /* NSObject+MTLComparisonAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 90E3A46DADAE808ABCF8DA093A1F0A37 /* NSObject+MTLComparisonAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		83B2581466924E92C1A63FA109400294 /* MTLJSONAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B78B5F838295F2C6CCA0316BE4A7C97 /* MTLJSONAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		83C9C8C59AE16FF7E3935AAE85550054 /* NSData+SnapchatKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AC6595E4B0F1881632644CBC0879775 /* NSData+SnapchatKit.m */; };
+		8482FA643C417D3346126983B1CE2163 /* ExtendableMessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 151083D0F45656947CF1BAD22F86B9EE /* ExtendableMessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		84AC3B4799877F69BA26022A4074D5A5 /* MutableExtensionRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DD538EFE6D0B801F385F20D93048AED /* MutableExtensionRegistry.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		853344F944576EF29BF0925C878D23D8 /* UnknownFieldSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FDCF9C141D2B76551E065804EB72AF7 /* UnknownFieldSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		85DB71B674B21FC4069B3172E010757F /* SKLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 25B50FC7D431013529A4EDF7982F6C0A /* SKLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		86319C7A3EED59A06A3A15D78B09693B /* ExtensionRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 06B966634B688674E5961D625443E7E4 /* ExtensionRegistry.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8658349B9E14201EDFD7D4697801AB42 /* NSDictionary+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B9085E7485D99346EF2A43B26F8F498 /* NSDictionary+MTLManipulationAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		8693A017630AD73BE9AE77857D0BB232 /* WireFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E8F6A76DF1D61C5C7225F9DDCD74CA3 /* WireFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		86A7957E1DB85234A4BBA94F8CE796A4 /* SKSession.h in Headers */ = {isa = PBXBuildFile; fileRef = AA054E5F64577F7C772D73102EF8F7C1 /* SKSession.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8745E60DE9438702B88C9FA9D8DA0DCC /* NSObject+MTLComparisonAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 90E3A46DADAE808ABCF8DA093A1F0A37 /* NSObject+MTLComparisonAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		878704AEA48E0CC2EB5587E0CE833CF4 /* zip.h in Headers */ = {isa = PBXBuildFile; fileRef = FB2D208BA9563060C0278C6D8F71C479 /* zip.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		87C8E91488B9B212F2A118EEECDB14C7 /* SKClient+Device.m in Sources */ = {isa = PBXBuildFile; fileRef = DDF462ACA7D6BE321BE504088CFC8EC9 /* SKClient+Device.m */; };
+		881FB8FA6D215FEB9E3D7B342B969A0E /* NSDictionary+MTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = DF085137EB0F35B5B37260EABF2BC4FF /* NSDictionary+MTLManipulationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		885794CDC9F77A421C1DB599DADEA5D6 /* NSDictionary+SnapchatKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 3337FCDB5568A74D24743FFB6337720A /* NSDictionary+SnapchatKit.m */; };
+		893613DA1F6BA1A3C33ADAC7B0FE2520 /* NSString+SnapchatKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 54460D90C5A5A625598F1A72569A13B5 /* NSString+SnapchatKit.m */; };
+		893F938ED76EE7673A7A0F6C17CD0F70 /* SKAddedFriend.m in Sources */ = {isa = PBXBuildFile; fileRef = 168FBDE79E6B224781B59DDED990CC1D /* SKAddedFriend.m */; };
+		8949D2527E61AA5087E196CD4547FC98 /* metamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 184E597AA48D3822ECF8AEB2135DD087 /* metamacros.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		89ABF1D2530B99C2267887C1689242AB /* SKCashTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A0F9C65CF3106FAC238CDC512FF51E2 /* SKCashTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A403109FD2BF4AACE5A2FE90CF7D916 /* SSZipArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = 0595D336EA25C014342530119C843CA6 /* SSZipArchive.m */; };
+		8A54A95F2FD1C095901A65A071A5F730 /* ExtendableMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 00655651C6BA81463B1F1AC19D408EFB /* ExtendableMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A7FBB916C343C830946186B34BCE7A7 /* SKSnapOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 102BD1F037C4B0705E82FACAADBC648A /* SKSnapOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8AB80666C594FAC7D8C987FB14637FE7 /* SKClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E0A9E84EC29594B57D6036A4B137EB0 /* SKClient.m */; };
+		8B1FA0EA3807FD8856BDDF29F062748C /* SKSnapResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FBEB3B3FA6CC7990C60F15777A0090E /* SKSnapResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B56ECEF3192D42F101031F657E5A880 /* ForwardDeclarations.h in Headers */ = {isa = PBXBuildFile; fileRef = 67B7031A1CFE11F0B693963D8F04BA39 /* ForwardDeclarations.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B65A25E3DB1397009D9C6CCB10A9C1C /* SKSimpleUser.m in Sources */ = {isa = PBXBuildFile; fileRef = C2CC45708F858B3A21FA14F2C3AE0C49 /* SKSimpleUser.m */; };
+		8B75EDAFEAD28F8D92FE8216A16888FC /* SKThing.h in Headers */ = {isa = PBXBuildFile; fileRef = E9AF192BD8DD526AEB6FD5A02EEB2A56 /* SKThing.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8C2B5C50D6D72F51C6240F7F9750A892 /* NSValueTransformer+MTLInversionAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FDC119599936009F4BBDAE2B034A189 /* NSValueTransformer+MTLInversionAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		8C4E7CA7C2ECD97C9848176090E0F4D6 /* GeneratedMessageBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 463D5934C525845DDF6D4108DF174801 /* GeneratedMessageBuilder.m */; };
+		8CD58B6E46D98F6B469F0D53E56F3142 /* AbstractMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E3B442CA4C99021E31A08D4467D4203 /* AbstractMessage.m */; };
+		8CFA5839CA58FB25CBD751B76D8AA86A /* NSData+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 1508934AF2E2EE2B2C6287E8D0FD729E /* NSData+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8D4237E557C43F0CF261721C8889AD63 /* SKStoryUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = 774C527EA09A09E0D8CD014D643D2268 /* SKStoryUpdater.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8DB774211405DA6D9DC3AC9B4BF3AB59 /* MTLJSONAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B78B5F838295F2C6CCA0316BE4A7C97 /* MTLJSONAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8E02D789287764E4CDF11A66546B5030 /* CodedInputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = D64A94D4DFB38E5653DD76D20218BE09 /* CodedInputStream.m */; };
+		8ED0BD420D3AB8E37C06CFBADABBC5CC /* ConcreteExtensionField.h in Headers */ = {isa = PBXBuildFile; fileRef = 6826B1CCA448E90716D8C1B6E74BC68B /* ConcreteExtensionField.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		90890CCD9FAFA3E17B7F50715A030987 /* SKConversation.m in Sources */ = {isa = PBXBuildFile; fileRef = 979970EC473F3B7EC64A997D0DAB7410 /* SKConversation.m */; };
+		908A58094D68486876A366AFC5589582 /* MTLTransformerErrorHandling.h in Headers */ = {isa = PBXBuildFile; fileRef = C93DEA42EF984A92E5FFF4F5EA4C4576 /* MTLTransformerErrorHandling.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9121F000E62DE87B8CF8DA11EA769789 /* ConcreteExtensionField.h in Headers */ = {isa = PBXBuildFile; fileRef = 6826B1CCA448E90716D8C1B6E74BC68B /* ConcreteExtensionField.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9132D10211BE3A8EF9BD2A643A5980D6 /* NSValueTransformer+MTLPredefinedTransformerAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = FB0E1FAC0060ECAB08CEE29646BFE32A /* NSValueTransformer+MTLPredefinedTransformerAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		915FB623F1795824405471A9F6BA53F1 /* SKConversation.h in Headers */ = {isa = PBXBuildFile; fileRef = FEBB2E828CE404D19FE3169CB4CE45B6 /* SKConversation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		91CE73A494F556301D37BC9F4B69A9BE /* Utilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FADA08C22B41CD08228C4250C6B1A70 /* Utilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		92789D62469A30E60FA89AB348E37E2D /* MTLModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 35985918E56AD9E0C441B57EF60B263E /* MTLModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		92B5E1E35104C244A329C23A1E449BEC /* ExtendableMessageBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D2C9634F9F032DDCBE25B9910E30A5A /* ExtendableMessageBuilder.m */; };
+		93279811007137D5DAE3A3060A7970D7 /* SKSnap.m in Sources */ = {isa = PBXBuildFile; fileRef = 802057E388A43AE12453D12948E1951C /* SKSnap.m */; };
+		93769114AF59E54CED8772DAD7EDC30F /* NSData+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 1508934AF2E2EE2B2C6287E8D0FD729E /* NSData+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9388EAE8DD4E0193CFAA60A4F674FE5A /* SKMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 0CA59E7E475EC4C780AB17196EE1F175 /* SKMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		94077C3B5FC298217A2A747965A4BF92 /* SKClient+Discover.m in Sources */ = {isa = PBXBuildFile; fileRef = 3483A1EC7B5CF9FAD309261F6519CDF3 /* SKClient+Discover.m */; };
+		956A6E6A412D2CBEE8799C1F4CCFC07F /* Pods-SnapchatKit-OSX-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 34BB852EFABC59BAFCA45806008FB3B0 /* Pods-SnapchatKit-OSX-dummy.m */; };
+		95E3F7B7AE361A0A5D17D7ED1FB8B8D5 /* ConcreteExtensionField.m in Sources */ = {isa = PBXBuildFile; fileRef = 7451E9844399D33B0EF8F081DEE45BB9 /* ConcreteExtensionField.m */; };
+		9726F338A0C2308D6F9A32F70A2621C3 /* SKClient+Account.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CBC1007B50FB6D8D8CCC49C9AA3A908 /* SKClient+Account.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		975B8A09DBB1BC1F01181A5A1AC28719 /* SKStoryOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2349A4CD323EDCB9F3445312B2F9489A /* SKStoryOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		97828A757420065134A817CDE0666A6D /* GeneratedMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = B3547AAE494746F0CF2277659F9390E4 /* GeneratedMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		978AB5F23A70FD0FFCAE67531BED2BFD /* SKMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 0CA59E7E475EC4C780AB17196EE1F175 /* SKMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		98203E3249D625F706F6FCA2482D971F /* NSArray+SnapchatKit.m in Sources */ = {isa = PBXBuildFile; fileRef = F20808D5847A1BE5576F1E97363F4126 /* NSArray+SnapchatKit.m */; };
+		985FB0D650981B7D97E84F1A97B4F9D5 /* zip.c in Sources */ = {isa = PBXBuildFile; fileRef = 4F0F9FF93E2C703E32F8511026F85347 /* zip.c */; };
+		9868A999F686B77A09B2F5E1451115A4 /* ioapi.h in Headers */ = {isa = PBXBuildFile; fileRef = B99D5FA99A6C1A06B1CC07FF55B44986 /* ioapi.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		987A092009A08734CCB6CD47990EB207 /* NSDictionary+SnapchatKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 3337FCDB5568A74D24743FFB6337720A /* NSDictionary+SnapchatKit.m */; };
+		98D1C7B474D58C8E202F41AABFF874F9 /* NSDictionary+SnapchatKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 3337FCDB5568A74D24743FFB6337720A /* NSDictionary+SnapchatKit.m */; };
+		98DB39B010A26293D6320822C4358726 /* SKThing.h in Headers */ = {isa = PBXBuildFile; fileRef = E9AF192BD8DD526AEB6FD5A02EEB2A56 /* SKThing.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		98F3CAD0BECEB44DF487E880AC8817E2 /* SKConversation.m in Sources */ = {isa = PBXBuildFile; fileRef = 979970EC473F3B7EC64A997D0DAB7410 /* SKConversation.m */; };
+		99026B2C8C968E88DEB1D7CEA021F90B /* ioapi.h in Headers */ = {isa = PBXBuildFile; fileRef = B99D5FA99A6C1A06B1CC07FF55B44986 /* ioapi.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		996AA48FF48E0EF26C5E5317AD160D65 /* SKRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = E723F5E599FCD85ABFD4F911E3DDDE5F /* SKRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		997674D7B460BEF3BB195BEB8327B01E /* GeneratedMessageBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 463D5934C525845DDF6D4108DF174801 /* GeneratedMessageBuilder.m */; };
+		9A3EBC3748D4F4F48DA2A0133A438B36 /* Pods-SnapchatKit_Example-Mantle-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = BA7F4D5E4C8595A3D1AE0EB307C2CB8E /* Pods-SnapchatKit_Example-Mantle-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9A99F08C293A16C31870858C276DFD94 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = A7E0035C4D44DD28CDC29DBEE88C9580 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		9B97BEF2E3CBC1E97617A003F1B98E0A /* SKClient+Stories.m in Sources */ = {isa = PBXBuildFile; fileRef = 9AAF0F4CF61FEBE5F27F076EE43534B6 /* SKClient+Stories.m */; };
+		9BD5C2540AB3E6938E65AF75410E336F /* SKUserStory.m in Sources */ = {isa = PBXBuildFile; fileRef = EBF31098D1B73D4027EF54C1B7EC55E7 /* SKUserStory.m */; };
+		9BD952A5A55EBB202F43317F9835BD07 /* Field.h in Headers */ = {isa = PBXBuildFile; fileRef = AEA4DB5D58231D27AC6CDE90D7240533 /* Field.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9BDF151726D1BE8BA801562B4E9742E1 /* SSZipArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = 0595D336EA25C014342530119C843CA6 /* SSZipArchive.m */; };
+		9C2C9B6ED4A12B7E5EDA5954CE4BE54A /* SKNewConversation.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A537E793DA2330169541319E2AD1A2A /* SKNewConversation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9C9F0AE0C0F996C55440D182852763D9 /* SKNearbyUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 4825B54E2CDC5AA561EF544825F2A14F /* SKNearbyUser.m */; };
+		9D0155280BABA02C5A7095272881FC01 /* SKSnapResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = DD4D2DD38DC19BF04525CD76056DF23B /* SKSnapResponse.m */; };
+		9D2309809BF676276FF378C25B22D6AE /* SKFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 7548F1AD067B99B153C9CFDB0BC160DC /* SKFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9D3895FEB26B81C4B54BAF5888624EAA /* MTLReflection.h in Headers */ = {isa = PBXBuildFile; fileRef = 14DA7638F179D4435E88DD761A6C54AF /* MTLReflection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9D42B50B048BF376F42AA52607149E0D /* CodedOutputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = AA7B9832442745B728000CCF09AD59A2 /* CodedOutputStream.m */; };
+		9EB5F8A60C6EDC5104106616834E96BC /* EXTScope.h in Headers */ = {isa = PBXBuildFile; fileRef = B9231F31123010FDAB359C1EE6306140 /* EXTScope.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		9F2BD5B80A442D5B2FBAF70AD5451E2C /* PBArray.m in Sources */ = {isa = PBXBuildFile; fileRef = 80833A66B09D6D42B65135FA200C959A /* PBArray.m */; };
+		9F97D4F0862F7DA7326BEB67E4F2938A /* GeneratedMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 7141EAD9F0391CA0B89AA690FD467035 /* GeneratedMessage.m */; };
+		9FE7CB5B685FDB50EAE1A50C5F72AE44 /* AbstractMessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 978BF2612AD5B68A7A65BE361CCDD3DB /* AbstractMessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A004779939817C1A50DB833B43277E8F /* NSArray+MTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 06531AAEF120FF70E927F40F0A61C49D /* NSArray+MTLManipulationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A0AC30763233BA7BD6A9412109AB62DB /* EXTKeyPathCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = F1D1A5B737A29E03602B5C8212455D59 /* EXTKeyPathCoding.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A0DF13C7AD7438F4375B93128DB21EF1 /* SKClient+Chat.m in Sources */ = {isa = PBXBuildFile; fileRef = 23C622E56337996E2A8713254F5BD246 /* SKClient+Chat.m */; };
+		A104C68EC950DF3588B72706E85EC36A /* ExtendableMessageBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D2C9634F9F032DDCBE25B9910E30A5A /* ExtendableMessageBuilder.m */; };
+		A157A724B33E65EF87E114BD4E759500 /* SKClient.h in Headers */ = {isa = PBXBuildFile; fileRef = DE3FD306D6487F5A6E0F63B0BA4493A1 /* SKClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A179FCC27048DC3FDEB966BAB5CAF63A /* mztools.h in Headers */ = {isa = PBXBuildFile; fileRef = 1685FA7977E1A72A8CA039CF99A88D23 /* mztools.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A2592BA00080A783E4E6AC1AE915C314 /* RingBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 31F648378E994908BE3DEFFBD2CEB0CB /* RingBuffer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A287CC2E728344F3FA6D92F230D2B4E5 /* ForwardDeclarations.h in Headers */ = {isa = PBXBuildFile; fileRef = 67B7031A1CFE11F0B693963D8F04BA39 /* ForwardDeclarations.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A2936D824BBBEA30F74B6402654D0540 /* MutableExtensionRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 39300C3939F3E500421A1E0654225D36 /* MutableExtensionRegistry.m */; };
+		A5279C159B4D0BFDD022A0BC824B4A41 /* SKSharedStoryDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = E6316AA0C110D87D7C0CEE4F992074FC /* SKSharedStoryDescription.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A574C2C6D2ACECD58389B141A6F1E391 /* AbstractMessageBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = C1F491F9A8489CC37E4E1795E1924489 /* AbstractMessageBuilder.m */; };
+		A63F55B596C36DC6FAE1916920BA2C4D /* SKStoryNote.h in Headers */ = {isa = PBXBuildFile; fileRef = 94AE3C50908C86AECCE17C5B46647395 /* SKStoryNote.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A68C5637F3A72037EB47243C39388E5C /* SnapchatKit-Constants.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C57F7FD8AC70A5A980E7C0460CA2485 /* SnapchatKit-Constants.m */; };
+		A69CF9AB373B5BF54933D4BCBDD24B8A /* MutableField.h in Headers */ = {isa = PBXBuildFile; fileRef = E6B8AC488192EFFE38ABFA7054D5FAE7 /* MutableField.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A6CD5AF026F0476BFA019BA291B70CA1 /* Pods-SnapchatKit_Tests-Mantle-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A362FEDA412E6EA8B1971C25C70FDA47 /* Pods-SnapchatKit_Tests-Mantle-dummy.m */; };
+		A6DB9B2A5EBA640EC7ABDE1CDF72CFCC /* UnknownFieldSetBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = F4B5E1A7AAE7E607AC9E54D4FA333BAB /* UnknownFieldSetBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A75E694DA35CE46237D3311DDAF8E8E9 /* SKThing.m in Sources */ = {isa = PBXBuildFile; fileRef = 9172B364044C193573346831B47E3C32 /* SKThing.m */; };
+		A95A1AE1DE0E8B75BF1A203BFFAC2595 /* NSArray+MTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 06531AAEF120FF70E927F40F0A61C49D /* NSArray+MTLManipulationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA0BD7F44E7BEB9A8E6D5B83E7CBA2C0 /* SKUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 5515DC27DAB5541F75B0AA3425061AAE /* SKUser.m */; };
+		AA19F2DC4D4C3C1D51FC12FBB40043F4 /* SKSnapResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = DD4D2DD38DC19BF04525CD76056DF23B /* SKSnapResponse.m */; };
+		AAC28F6DC761DADDBCB2ED306E4807A6 /* WireFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = 4687F307C6DF4771125FACD4FEF41B6F /* WireFormat.m */; };
+		ABD235416293C0D6BC8BF36962AABB43 /* SSZipArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = 864E8CC81A76CA838F6299352A05BC9D /* SSZipArchive.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AD2E7752B133F855C03C5F1B1D188820 /* ExtensionRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 37186F3BDEF4361A87EE611FE929CFB9 /* ExtensionRegistry.m */; };
+		ADEC9C941BFB1070DF9545CD1EEFA9C8 /* NSObject+MTLComparisonAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 90E3A46DADAE808ABCF8DA093A1F0A37 /* NSObject+MTLComparisonAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AE22BE5B8F66CCD2942B8D28628BC51A /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = A7E0035C4D44DD28CDC29DBEE88C9580 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		AE372FF96627076C1B6D8659648C45F4 /* SKSnap.h in Headers */ = {isa = PBXBuildFile; fileRef = 48D10AA8FB91C836871332883EEE8C79 /* SKSnap.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AE70AC3F7CFEC76E3E616333BF1F854A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46EF97B3320D5567B3CD996D681E6DB9 /* Foundation.framework */; };
+		AEF4C40AF3FDE0931244614A70AC9910 /* MutableField.m in Sources */ = {isa = PBXBuildFile; fileRef = 709485E58BF2FF0A4C686203BE95E8EB /* MutableField.m */; };
+		AF2B8C4FFD7B9FDFBFB1F27C0054ED5C /* AbstractMessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 978BF2612AD5B68A7A65BE361CCDD3DB /* AbstractMessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AF454BAAC58CB4B904C62B393C392345 /* mztools.c in Sources */ = {isa = PBXBuildFile; fileRef = 884007D97EAC905D528F2D798D498CA3 /* mztools.c */; };
+		AF603D752936B17358AB6FF4246D6C09 /* Attestation.pb.m in Sources */ = {isa = PBXBuildFile; fileRef = 606FE432D85DF39B09C3DE7E82B31AD7 /* Attestation.pb.m */; };
+		B0C4CE31D4BA47F6DF5A10AC79DC3A6A /* SKCashTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A0F9C65CF3106FAC238CDC512FF51E2 /* SKCashTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B0C615AECE49899C2361FDFBBD35CAB7 /* SKBlob.m in Sources */ = {isa = PBXBuildFile; fileRef = EC153DEC3715CFBB867734E4DCF5C9D6 /* SKBlob.m */; };
+		B0D9197026A81388B71196FFF4D5BB06 /* crypt.h in Headers */ = {isa = PBXBuildFile; fileRef = 79F59B49CE4DC99DF440AE4D85E72F6C /* crypt.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B12B5D15D4404721BDC3696C7A629AF5 /* AbstractMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E3B442CA4C99021E31A08D4467D4203 /* AbstractMessage.m */; };
+		B15127483D4E7BEB3DD36CCED6617C8C /* Field.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DC6C59C7DEA6461C564B1DA58829542 /* Field.m */; };
+		B1B806F787A2841D03ADB6E235DB5756 /* Mantle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73839BEC40DA572D986E82BD377F57E7 /* Mantle.framework */; };
+		B27523C2DE3F1E3134712528C0F750A4 /* Field.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DC6C59C7DEA6461C564B1DA58829542 /* Field.m */; };
+		B28D218A54569D6D4E6242C19557860F /* EXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = C994D8C3A0E2BD2F6A50788977A698B4 /* EXTRuntimeExtensions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		B300232873C207599BBB51BE2CDA97B6 /* SKClient+Device.m in Sources */ = {isa = PBXBuildFile; fileRef = DDF462ACA7D6BE321BE504088CFC8EC9 /* SKClient+Device.m */; };
+		B34DA3C60AFDAAAEA2C27A5D5C45763D /* SKRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = E723F5E599FCD85ABFD4F911E3DDDE5F /* SKRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B3AD53F71382D3CCDFFBF55DFAA15121 /* SKStoryNote.m in Sources */ = {isa = PBXBuildFile; fileRef = E7264B33B0A0713CE212280490FD1800 /* SKStoryNote.m */; };
+		B44551B05613F7C209980BA8F692E06A /* SKSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 0460FB606CE25E0ACED9CBF453B53217 /* SKSession.m */; };
+		B504BF8CA9CAFBB209026B4A7E190A33 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1742A790724662C0CC15EE77EC86B83 /* Foundation.framework */; };
+		B64D3BCF60253BC795C2B97945369172 /* SKRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9412679689721ADFAAC7A895E02BA5AE /* SKRequest.m */; };
+		B7F404289D804A430D779CF68F79E750 /* Descriptor.pb.m in Sources */ = {isa = PBXBuildFile; fileRef = 55BA9EA15DD7130BEC47C5B99EC9384A /* Descriptor.pb.m */; };
+		B802D1B39FEEBEE89FD960A80BA90AE2 /* SKFoundFriend.h in Headers */ = {isa = PBXBuildFile; fileRef = 93D7F125345B7EE254042449068E0D63 /* SKFoundFriend.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B95738039B80FB553C404FEA1CA843D1 /* Attestation.pb.h in Headers */ = {isa = PBXBuildFile; fileRef = C90F6DCB8E6D5E5AD3B2C839EDF984C8 /* Attestation.pb.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B97B55B25D25910CDEE35D46EE8CED75 /* NSValueTransformer+MTLInversionAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 58BA9F3FC2DC449A0D601CAFBB661733 /* NSValueTransformer+MTLInversionAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B9FB2048F4E99A5867CC972C0CDCD527 /* SKUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 5515DC27DAB5541F75B0AA3425061AAE /* SKUser.m */; };
+		BAED1E04C71874842555DB3B7C492E26 /* SKCashTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = F33789AB1CD889C76EE417221D59C3D9 /* SKCashTransaction.m */; };
+		BBD51C8B83ED3761DD5A40F120427D25 /* SKNearbyUser.h in Headers */ = {isa = PBXBuildFile; fileRef = AF2BABB30D0A63B528450704A8CC4831 /* SKNearbyUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BD4E59EDF409CBFD9D9728ACF6AA5881 /* EXTScope.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D5F2EFE545E38C869A6A2D1EABEFE6F /* EXTScope.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		BE331BBE584C5DDA5061F18B0DBD43F7 /* RingBuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = D7AD70060269B4629B407FE76BD9B976 /* RingBuffer.m */; };
+		BF596A9358398FD70766E2748274387F /* Pods-SnapchatKit_Example-Mantle-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = CBA1FDCD70D710D40E0FEE2504BB4C9B /* Pods-SnapchatKit_Example-Mantle-dummy.m */; };
+		BFEF6C043A14EAA70813835B40CD4868 /* SKFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 84C3168646A0D3D84DBEAC87C1C0BDA6 /* SKFilter.m */; };
+		C0890754A06E690B5CF7779383382159 /* SKFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 84C3168646A0D3D84DBEAC87C1C0BDA6 /* SKFilter.m */; };
+		C0C929E4ACF3F3B5708EED5A60383238 /* WireFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E8F6A76DF1D61C5C7225F9DDCD74CA3 /* WireFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C0EA1387BAA8FF2AD0E93B2F5E2AEC07 /* SKAddedFriend.h in Headers */ = {isa = PBXBuildFile; fileRef = 65C6A40590103EE3AACC40219CF10B19 /* SKAddedFriend.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C163572BA817FF6475CA9D3628ABB3DA /* metamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 184E597AA48D3822ECF8AEB2135DD087 /* metamacros.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		C173C3B5DACE68FF25CAF5642887DD2E /* UnknownFieldSet.m in Sources */ = {isa = PBXBuildFile; fileRef = E7FF2C7F1C9F03E9F9FFEEEB71828E5D /* UnknownFieldSet.m */; };
+		C253F506F8C862B9018A0587DB20A7E0 /* SnapchatKit-Constants.h in Headers */ = {isa = PBXBuildFile; fileRef = CE4ABDF04FF8494E1C5D6E053D288B2A /* SnapchatKit-Constants.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C36799F94CDBC5D09A98A0A547AD3509 /* mztools.c in Sources */ = {isa = PBXBuildFile; fileRef = 884007D97EAC905D528F2D798D498CA3 /* mztools.c */; };
+		C439369054238B8A0E00645EDEAF398F /* SKClient+Account.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CBC1007B50FB6D8D8CCC49C9AA3A908 /* SKClient+Account.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C5162F5ED425FB21237997AE5CC4898A /* SKCashTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = F33789AB1CD889C76EE417221D59C3D9 /* SKCashTransaction.m */; };
+		C5FAD05BFDDA22A0AB15ECCB8629965A /* SKClient+Device.m in Sources */ = {isa = PBXBuildFile; fileRef = DDF462ACA7D6BE321BE504088CFC8EC9 /* SKClient+Device.m */; };
+		C645928E34D41BA10A71023575AF62E7 /* SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E8E9BC41A16B11C168D078CD7578264 /* SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C65F16F13CE8CEA0269420C9419982A2 /* SnapchatKit-Constants.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C57F7FD8AC70A5A980E7C0460CA2485 /* SnapchatKit-Constants.m */; };
+		C90B67B4290DEEA44470BF1577F4C8C6 /* CodedOutputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = AA7B9832442745B728000CCF09AD59A2 /* CodedOutputStream.m */; };
+		C934D4DE7B8A6482E32139C0428CE9EE /* ObjectivecDescriptor.pb.h in Headers */ = {isa = PBXBuildFile; fileRef = CDF8D63AD3F269AECF961EB562B4584D /* ObjectivecDescriptor.pb.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C9388804DD7EF158C738FB4F08259FDD /* SKClient+Chat.h in Headers */ = {isa = PBXBuildFile; fileRef = 97ABC90E3828E9031BC4F158D4F3EEE2 /* SKClient+Chat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CA5E2D8CEEC6C21F914C8FB7749CCA96 /* GeneratedMessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 6192CF7FB23184D714C51581F7A1A1BE /* GeneratedMessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CA6E5BA7CA966310534FE4C22A0950F9 /* SKThing.m in Sources */ = {isa = PBXBuildFile; fileRef = 9172B364044C193573346831B47E3C32 /* SKThing.m */; };
+		CA8B1C94080A42E191AD633351906F64 /* NSArray+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = B29E8F6A2790D070998F9CF5CF7EE4D1 /* NSArray+MTLManipulationAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		CB0E9CFE7C2426784AF97517C83C9578 /* SKAddedFriend.m in Sources */ = {isa = PBXBuildFile; fileRef = 168FBDE79E6B224781B59DDED990CC1D /* SKAddedFriend.m */; };
+		CB69B27903511FCC32710C6B799A3103 /* SKClient+Stories.m in Sources */ = {isa = PBXBuildFile; fileRef = 9AAF0F4CF61FEBE5F27F076EE43534B6 /* SKClient+Stories.m */; };
+		CC45F5926EDC33CFDEDCA69191042A78 /* SKStoryOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2349A4CD323EDCB9F3445312B2F9489A /* SKStoryOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CC91A48CA4DDA6014C0B2ADB8899108F /* SKStoryCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D74C791C2358D9D5C3D0605B6C1FE5A /* SKStoryCollection.m */; };
+		CCDC21DA0FAB1837A8D4D94E3051457E /* ExtendableMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 00655651C6BA81463B1F1AC19D408EFB /* ExtendableMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CDDDA9F0CAA7C9B3D08CFBD9B9ABCDB4 /* MTLValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 18B61B312FEA02DCE16514E7C4A29FBA /* MTLValueTransformer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CDFE542F4E6B55DB53B4C16C500C328A /* unzip.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FE550472E08ABD8D5B741D1077F61BA /* unzip.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CE05F613D4B6C6F6F13C5237ED8DD23F /* NSDictionary+MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DF9455276C69ACF288FDCEEB316B212 /* NSDictionary+MTLJSONKeyPath.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		CF2FDC3BE87FF50F5030F93491656E0E /* MTLModel+NSCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = D917EDD76808D4D21F22960E1DE309C8 /* MTLModel+NSCoding.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CFE6FA04E3BA20BAAA7D29D16E21DFB7 /* SSZipArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = 864E8CC81A76CA838F6299352A05BC9D /* SSZipArchive.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D0E98E6916C59A771CE7C86D511FD055 /* CodedInputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = D64A94D4DFB38E5653DD76D20218BE09 /* CodedInputStream.m */; };
+		D1465806DEA963CAA3584333FA6D75A7 /* PBArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A69F98F1A3DEA5E52B393E4CA8AEAF9 /* PBArray.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D166AC5F574F281F986AE8225F7C894D /* ForwardDeclarations.h in Headers */ = {isa = PBXBuildFile; fileRef = 67B7031A1CFE11F0B693963D8F04BA39 /* ForwardDeclarations.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D1AB726477E70D4EC3B9A717E4D2433F /* UnknownFieldSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FDCF9C141D2B76551E065804EB72AF7 /* UnknownFieldSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D1C5FB6E0C236942AFE5AAA5AAFF5655 /* CodedInputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 04365EC94A261DF5AA309962BFE4E7AA /* CodedInputStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D1E0716F92E6511E55B5B96ED4AEC4C8 /* Bootstrap.h in Headers */ = {isa = PBXBuildFile; fileRef = 30F3816561C0672DD603262F36C61EB4 /* Bootstrap.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D209D6CC69F6B7EBEDBB9B94FC2B1553 /* MTLValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 30966F6B3985DE33FEB91E8D08220629 /* MTLValueTransformer.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		D23DDBDFBAE8C4C9A5716B13D3FAA378 /* MTLModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 35985918E56AD9E0C441B57EF60B263E /* MTLModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D282D374F9873392A05853818A6D5B0E /* Attestation.pb.h in Headers */ = {isa = PBXBuildFile; fileRef = C90F6DCB8E6D5E5AD3B2C839EDF984C8 /* Attestation.pb.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D2F78FAE5B3A0C938FB4B80EBF1923B3 /* Pods-SnapchatKit_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FAFA003B01F71668975B806F52809BB /* Pods-SnapchatKit_Tests-dummy.m */; };
+		D37ACE9495FF884617BBCD7F3FFE417F /* SKClient+Friends.h in Headers */ = {isa = PBXBuildFile; fileRef = 833D0F7844FB6F9844FF13EF09871134 /* SKClient+Friends.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D45B5067BF9C0F537E9B7B065E2260D0 /* SKLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 81A6A60094231EA88DCE60750AA13AE1 /* SKLocation.m */; };
+		D45D9A9623C63E31614320ACE4538E4F /* SKClient+Device.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E8C22914F0D53BA79853BCCAE38D6A0 /* SKClient+Device.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D46E1A27F558BDE48CB9864387E071F4 /* SKUserStory.h in Headers */ = {isa = PBXBuildFile; fileRef = C24C62067E53B9DD2EB633790E6EECEA /* SKUserStory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D4981261FDC830FB300EAB1622BD0870 /* unzip.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FE550472E08ABD8D5B741D1077F61BA /* unzip.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D4D48852B717CB359D93200343D510F5 /* SKNearbyUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 4825B54E2CDC5AA561EF544825F2A14F /* SKNearbyUser.m */; };
+		D4D4A182342E38D86F482C196CE6B342 /* Mantle.h in Headers */ = {isa = PBXBuildFile; fileRef = 59F7C50BC794CD8AE4A522E621CBDEB2 /* Mantle.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D52F21DDC605DA93D427D439E4FCEB02 /* UnknownFieldSetBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = F4B5E1A7AAE7E607AC9E54D4FA333BAB /* UnknownFieldSetBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D53BA31AD32B6016050C026A2183E05A /* SKFoundFriend.h in Headers */ = {isa = PBXBuildFile; fileRef = 93D7F125345B7EE254042449068E0D63 /* SKFoundFriend.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D5593FE4E5038E58BA2EAA7B13FB38A8 /* NSDictionary+MTLJSONKeyPath.h in Headers */ = {isa = PBXBuildFile; fileRef = A3A065B43F6F4A3AB98235E4C41E9E6A /* NSDictionary+MTLJSONKeyPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D5BD3AA4063590F4A80ED47C0369EFA1 /* Descriptor.pb.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A58A6FF946BC36ACBE07A96585CF06D /* Descriptor.pb.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D5EAFE3970AE950839C1468BFCD076C2 /* ObjectivecDescriptor.pb.m in Sources */ = {isa = PBXBuildFile; fileRef = 4149CC5EE78E849EAF5DEEFEE5B0AA66 /* ObjectivecDescriptor.pb.m */; };
+		D5FD3875D218393CAEB9EAC42B85C903 /* SKFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 7548F1AD067B99B153C9CFDB0BC160DC /* SKFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D6828D52214A4BA1D10A0C97A6E7E496 /* SKClient+Friends.m in Sources */ = {isa = PBXBuildFile; fileRef = A80EB289DF56408DBC3088C043E15245 /* SKClient+Friends.m */; };
+		D6863811354E312C7D4DDEED87509657 /* NSDictionary+MTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = DF085137EB0F35B5B37260EABF2BC4FF /* NSDictionary+MTLManipulationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D6E9A980F45113FC9B921F444BAD2F58 /* WireFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = 4687F307C6DF4771125FACD4FEF41B6F /* WireFormat.m */; };
+		D7011E098D94BD44843CF413BE1E8DCB /* zip.c in Sources */ = {isa = PBXBuildFile; fileRef = 4F0F9FF93E2C703E32F8511026F85347 /* zip.c */; };
+		D77A715DAD8A1C776CD34C1139CB8B20 /* MessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = E3D463D60137F8318D301057A1ECFDB5 /* MessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D96F3348897EB52002398839CF6407BF /* Mantle.h in Headers */ = {isa = PBXBuildFile; fileRef = 59F7C50BC794CD8AE4A522E621CBDEB2 /* Mantle.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D9AB44CFBFDCC7EDA69D5BA7A953BECD /* SnapchatKit-Constants.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C57F7FD8AC70A5A980E7C0460CA2485 /* SnapchatKit-Constants.m */; };
+		D9AE24C66EC8F86F6C6794256914021E /* NSDictionary+MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DF9455276C69ACF288FDCEEB316B212 /* NSDictionary+MTLJSONKeyPath.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		DA14ED2CE15397202863A58835616AE0 /* SKClient+Snaps.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FEA67B46E224685AD9C805D1A27E5D9 /* SKClient+Snaps.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DA15C7DBB4AF9459D0BF6660F61E11AD /* SKLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 81A6A60094231EA88DCE60750AA13AE1 /* SKLocation.m */; };
+		DA2AB6464AEFC1DBE969E84F5836188F /* NSObject+MTLComparisonAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 452A825C1C9779653BE134C643213E98 /* NSObject+MTLComparisonAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		DAF7AF94D28CAFD1ED64657BAFF890D4 /* GeneratedMessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 6192CF7FB23184D714C51581F7A1A1BE /* GeneratedMessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DB1EA51D93B03B1F6996245180D5781A /* UnknownFieldSetBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 15787D58A018F7C163848E0EDEFFF2AB /* UnknownFieldSetBuilder.m */; };
+		DBD779589C0EEF217F9BD85A4488DF71 /* ObjectivecDescriptor.pb.h in Headers */ = {isa = PBXBuildFile; fileRef = CDF8D63AD3F269AECF961EB562B4584D /* ObjectivecDescriptor.pb.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DBE0F807498A272A78CD08294B24ACEA /* SKUser.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DA60CBC900C38B9E72F99E56E639C3E /* SKUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DBF2B12D278ADD15E6581A1A761B8DC4 /* ioapi.c in Sources */ = {isa = PBXBuildFile; fileRef = 4EBD65303E77D9EF88B73826511C216D /* ioapi.c */; };
+		DC2BD42E5AE0E113899FE3A995FB94B9 /* EXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 747032A30F0B0CFAE55E25EE38C28805 /* EXTRuntimeExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		DCBC7AE273C3D00ED094C5FA527956CA /* SKClient+Stories.h in Headers */ = {isa = PBXBuildFile; fileRef = CEB772F1CD2E64A93211D413F991E158 /* SKClient+Stories.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DD262F615BA14F4CF16F59966D429D03 /* CodedOutputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = AA7B9832442745B728000CCF09AD59A2 /* CodedOutputStream.m */; };
+		DEA5708CAC1F0A0CB8A7F6BD2F04CC7C /* MTLReflection.m in Sources */ = {isa = PBXBuildFile; fileRef = 6549D674C4BBFC4AE9F553D4ABED4F95 /* MTLReflection.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		DEB5BA4CC6D4E8B4A618206E8081F9CD /* NSError+MTLModelException.m in Sources */ = {isa = PBXBuildFile; fileRef = A3B3600563469E165A512779D2952B19 /* NSError+MTLModelException.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		DF26D63341C55884A5ECB643D272B330 /* Pods-SnapchatKit_Tests-Mantle-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = FEC4C213ED5CC2EB2BD905D67424B9CE /* Pods-SnapchatKit_Tests-Mantle-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DF398EF5859B9F5086C1BE51410C5700 /* SKClient+Account.m in Sources */ = {isa = PBXBuildFile; fileRef = 20F34E602ECE0E9952C0C9CC8D2E971A /* SKClient+Account.m */; };
+		DF81798C84C2D3E1DF580686635F9669 /* SKUserStory.h in Headers */ = {isa = PBXBuildFile; fileRef = C24C62067E53B9DD2EB633790E6EECEA /* SKUserStory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DFEB980E4F4E57C5FEB401FB969406FC /* SKNewConversation.m in Sources */ = {isa = PBXBuildFile; fileRef = E6543108894562824171DF82C827C732 /* SKNewConversation.m */; };
+		E000175AD5BB793F4139692885D2E352 /* MTLTransformerErrorHandling.m in Sources */ = {isa = PBXBuildFile; fileRef = B0B3A02E4506C7059D914FEF250427E1 /* MTLTransformerErrorHandling.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		E0101E016B646965B82683EE89D7A669 /* metamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 184E597AA48D3822ECF8AEB2135DD087 /* metamacros.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E05AECFEBB7267D2C971F2A83797EE85 /* NSString+SnapchatKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 54460D90C5A5A625598F1A72569A13B5 /* NSString+SnapchatKit.m */; };
+		E0EDEDBD0C23C8846BE28771D2A09854 /* NSDictionary+MTLJSONKeyPath.h in Headers */ = {isa = PBXBuildFile; fileRef = A3A065B43F6F4A3AB98235E4C41E9E6A /* NSDictionary+MTLJSONKeyPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E23D57BFB4769ABEF5C651093A1B5D64 /* UnknownFieldSet.m in Sources */ = {isa = PBXBuildFile; fileRef = E7FF2C7F1C9F03E9F9FFEEEB71828E5D /* UnknownFieldSet.m */; };
+		E24816B991E55EE80A0B76199812A802 /* mztools.h in Headers */ = {isa = PBXBuildFile; fileRef = 1685FA7977E1A72A8CA039CF99A88D23 /* mztools.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E430B9441FFAAB0E2B802FC6BFFAA438 /* SKFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 7548F1AD067B99B153C9CFDB0BC160DC /* SKFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4B95563FE886803F236930DF455AC2F /* NSDictionary+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 523519361513D98C2F08E815B11DEF1B /* NSDictionary+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E5E105928FA9936BAE93F7876C13C6C5 /* Attestation.pb.h in Headers */ = {isa = PBXBuildFile; fileRef = C90F6DCB8E6D5E5AD3B2C839EDF984C8 /* Attestation.pb.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E6999BDF965B57D4A038B9CFFD76FA89 /* SKClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E0A9E84EC29594B57D6036A4B137EB0 /* SKClient.m */; };
+		E73B87CE570187A97236785B79B51AA9 /* SKClient+Chat.m in Sources */ = {isa = PBXBuildFile; fileRef = 23C622E56337996E2A8713254F5BD246 /* SKClient+Chat.m */; };
+		E73B896247578CA52A5CC132E60CCB9B /* NSData+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 1508934AF2E2EE2B2C6287E8D0FD729E /* NSData+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E75286444154B5008250E7ABF4A21E44 /* SKNearbyUser.h in Headers */ = {isa = PBXBuildFile; fileRef = AF2BABB30D0A63B528450704A8CC4831 /* SKNearbyUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E84B2361DBBA9E0D06A7FA057689E716 /* SKSharedStoryDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 783EA1ECC5FDE5F2CB4C6E1B8B5B9896 /* SKSharedStoryDescription.m */; };
+		E851FB1E0A716412B039FCA19CA6FB83 /* SKNewConversation.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A537E793DA2330169541319E2AD1A2A /* SKNewConversation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E90B162E1CC2FFCDFD08BE7A4DC3790E /* NSDictionary+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B9085E7485D99346EF2A43B26F8F498 /* NSDictionary+MTLManipulationAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		E94DA6BC5D83F8BF9762B3F908DFDB28 /* NSArray+MTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 06531AAEF120FF70E927F40F0A61C49D /* NSArray+MTLManipulationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA421C49ED5CB42A1E100FFE23A6F128 /* SKNewConversation.m in Sources */ = {isa = PBXBuildFile; fileRef = E6543108894562824171DF82C827C732 /* SKNewConversation.m */; };
+		EA882E0938950C8981FDC2CD09D2E905 /* NSString+SnapchatKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 01D3D233D27189A14C4D48B64946BEDC /* NSString+SnapchatKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EB65D934E0D62C636CE934DA5C9A7D04 /* SKClient+Friends.h in Headers */ = {isa = PBXBuildFile; fileRef = 833D0F7844FB6F9844FF13EF09871134 /* SKClient+Friends.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EBA05579591C2B62DABA4CEE0F877FD7 /* GeneratedMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = B3547AAE494746F0CF2277659F9390E4 /* GeneratedMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC6E285E97BC2568438B6ECEA648AD17 /* SKSnap.m in Sources */ = {isa = PBXBuildFile; fileRef = 802057E388A43AE12453D12948E1951C /* SKSnap.m */; };
+		EC947AED5B1095A376BDC2CFE21DDCDD /* Pods-SnapchatKit_Tests-SnapchatKit-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 558B475B8EB352B7580B26A69BF74125 /* Pods-SnapchatKit_Tests-SnapchatKit-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ED5C837809483B9C9AAA74610D4D4487 /* SKUserStory.m in Sources */ = {isa = PBXBuildFile; fileRef = EBF31098D1B73D4027EF54C1B7EC55E7 /* SKUserStory.m */; };
+		EEB188DDA5FA84A3833B10075DF8CD60 /* UnknownFieldSetBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = F4B5E1A7AAE7E607AC9E54D4FA333BAB /* UnknownFieldSetBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EEFD1F92F6CCEEA2C2C5803EAC2FF640 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46EF97B3320D5567B3CD996D681E6DB9 /* Foundation.framework */; };
+		EF806F7116EEA807CA2999CE29687C93 /* SKStory.m in Sources */ = {isa = PBXBuildFile; fileRef = 9269F78B7355A85A30F6036EEAAC51C9 /* SKStory.m */; };
+		F02AD884511F86B6072F31F21E65FD92 /* SKStoryNote.m in Sources */ = {isa = PBXBuildFile; fileRef = E7264B33B0A0713CE212280490FD1800 /* SKStoryNote.m */; };
+		F1001B8C74D414F6CDC31054A42C1111 /* Field.h in Headers */ = {isa = PBXBuildFile; fileRef = AEA4DB5D58231D27AC6CDE90D7240533 /* Field.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F1779AA857C28E41A28CFCAEAE7AB800 /* SKStoryCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = 45A8B9B178D3D50255BED3D0FCB98A78 /* SKStoryCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F18511E4DF971F9AF0462EF1164F88E9 /* ioapi.h in Headers */ = {isa = PBXBuildFile; fileRef = B99D5FA99A6C1A06B1CC07FF55B44986 /* ioapi.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F1D71D1C89028248B09C70E609D53ECE /* SKSnapOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F8EFE9CDCA52EC0CCBD1DF32DA061F4 /* SKSnapOptions.m */; };
+		F2A1C19B2F3B275D87FCA549545ED92E /* unzip.c in Sources */ = {isa = PBXBuildFile; fileRef = E76B54A5B681A52C9BF1A48F75B3DE3F /* unzip.c */; };
+		F3306B4D0AD2368F1784A8B01FD7D161 /* MTLValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 30966F6B3985DE33FEB91E8D08220629 /* MTLValueTransformer.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		F3A05D289FC621F6A6C9F3E6CF1DBE8D /* SKAddedFriend.m in Sources */ = {isa = PBXBuildFile; fileRef = 168FBDE79E6B224781B59DDED990CC1D /* SKAddedFriend.m */; };
+		F560CF8AE9C997FB694C90CFF64E5D14 /* SKSimpleUser.h in Headers */ = {isa = PBXBuildFile; fileRef = E54E26EDFAA3F10A36830DE50A7A5B14 /* SKSimpleUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F6C050F56A15ED6FCE70398A104B445D /* NSObject+MTLComparisonAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 452A825C1C9779653BE134C643213E98 /* NSObject+MTLComparisonAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		F79573CC859A0680C237044ADF482B40 /* GeneratedMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 7141EAD9F0391CA0B89AA690FD467035 /* GeneratedMessage.m */; };
+		F7B21C00A641625866299AE0F557B18C /* SKClient+Snaps.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B86B77A0AE12A3715630EF1051CE196 /* SKClient+Snaps.m */; };
+		F8FDA8D22AC9594294EB4F2E6FBC001A /* SKClient+Discover.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B6CEADD2D0C33311B5DF1F367E954A5 /* SKClient+Discover.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FA281CFC8D23630C6298B85EB2067212 /* ExtensionRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 06B966634B688674E5961D625443E7E4 /* ExtensionRegistry.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FA3E11724F59F5058E629867E1167457 /* ConcreteExtensionField.m in Sources */ = {isa = PBXBuildFile; fileRef = 7451E9844399D33B0EF8F081DEE45BB9 /* ConcreteExtensionField.m */; };
+		FA61B00A1EA848372BC2699F346285D3 /* MTLValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 30966F6B3985DE33FEB91E8D08220629 /* MTLValueTransformer.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		FA90C81955AD3BA889C557BAC4F47299 /* ExtensionRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 37186F3BDEF4361A87EE611FE929CFB9 /* ExtensionRegistry.m */; };
+		FB1535FDD51C777D055BEAD988F01B7F /* SKClient+Stories.m in Sources */ = {isa = PBXBuildFile; fileRef = 9AAF0F4CF61FEBE5F27F076EE43534B6 /* SKClient+Stories.m */; };
+		FB5972E82F0ADA356D484C47B039EB5C /* ObjectivecDescriptor.pb.m in Sources */ = {isa = PBXBuildFile; fileRef = 4149CC5EE78E849EAF5DEEFEE5B0AA66 /* ObjectivecDescriptor.pb.m */; };
+		FB9C1587270D3BCB443EA848DAEE4C5F /* PBArray.m in Sources */ = {isa = PBXBuildFile; fileRef = 80833A66B09D6D42B65135FA200C959A /* PBArray.m */; };
+		FC8BEEADCF2C29AAB4480DDF78D3161C /* SKStoryNote.h in Headers */ = {isa = PBXBuildFile; fileRef = 94AE3C50908C86AECCE17C5B46647395 /* SKStoryNote.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FD0B0BB955EDD70593FB790E473C489B /* SKClient+Device.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E8C22914F0D53BA79853BCCAE38D6A0 /* SKClient+Device.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FD565BCC15825600FA0591835CA5E334 /* SKSharedStoryDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = E6316AA0C110D87D7C0CEE4F992074FC /* SKSharedStoryDescription.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FD57BB6E523BDF45449940906AF33A62 /* NSDictionary+MTLJSONKeyPath.h in Headers */ = {isa = PBXBuildFile; fileRef = A3A065B43F6F4A3AB98235E4C41E9E6A /* NSDictionary+MTLJSONKeyPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FDC9243D7DD33C135502754F1F1F286E /* SKClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E0A9E84EC29594B57D6036A4B137EB0 /* SKClient.m */; };
+		FDEA050FD7978641030E57BEFE8FA338 /* Utilities.m in Sources */ = {isa = PBXBuildFile; fileRef = E059AC38BADB0D1B36F1843E1BE50C2F /* Utilities.m */; };
+		FED1C4AF2195F2A79F78E6A21E51C79B /* SKClient+Discover.m in Sources */ = {isa = PBXBuildFile; fileRef = 3483A1EC7B5CF9FAD309261F6519CDF3 /* SKClient+Discover.m */; };
+		FEDC22E4B5A3BF58B772CEA1463515FB /* Pods-SnapchatKit_Example-SnapchatKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D6CD685B05060FD7B7E01EF0D9851D1E /* Pods-SnapchatKit_Example-SnapchatKit-dummy.m */; };
+		FF789B5916DAE6C0D30932C9F259E3B8 /* MTLReflection.m in Sources */ = {isa = PBXBuildFile; fileRef = 6549D674C4BBFC4AE9F553D4ABED4F95 /* MTLReflection.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -DOS_OBJECT_USE_OBJC=0"; }; };
+		FFE4568A31AC84530AFAE54120EE6EE9 /* SSZipArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = 864E8CC81A76CA838F6299352A05BC9D /* SSZipArchive.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		0713F8E87E2B4B7093623855 /* PBXContainerItemProxy */ = {
+		0E3DA6C9301FC91647B763526B75D29F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 014DB266874CFCE9C5BCEB5E /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = A31A9C7B30E247854E48DC87;
+			remoteGlobalIDString = 18831A668A0553C0D85DC4D246371F0D;
 			remoteInfo = "Pods-SnapchatKit_Tests-SnapchatKit";
 		};
-		4C658D40249678B7A1170C58 /* PBXContainerItemProxy */ = {
+		2549D57756EA86442D8DE840850956D0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 014DB266874CFCE9C5BCEB5E /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = E18E7FFABB282ABAA8F80B98;
-			remoteInfo = "Pods-SnapchatKit-OSX-SnapchatKit";
-		};
-		4E85A322C74630019FFE358B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 014DB266874CFCE9C5BCEB5E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 5D594D2364F9E5EE2E88CA56;
-			remoteInfo = "Pods-SnapchatKit_Example-SnapchatKit";
-		};
-		5C211129D944DB51A0D7A581 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 014DB266874CFCE9C5BCEB5E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 879A906FB924617D2343F826;
-			remoteInfo = "Pods-SnapchatKit_Tests-Mantle";
-		};
-		9769921DA48916F4420E0D7C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 014DB266874CFCE9C5BCEB5E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = CB84C8C430CE14A5E2FF477E;
+			remoteGlobalIDString = 89CDA72857EF513C2576EBAF8DC1B118;
 			remoteInfo = "Pods-SnapchatKit_Example-Mantle";
 		};
-		E6504F04604812A241536E5B /* PBXContainerItemProxy */ = {
+		2755A1CC3ABAC9867A40A2257BB6FF64 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 014DB266874CFCE9C5BCEB5E /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 26409AAF5D1F27C007C9DE5E;
+			remoteGlobalIDString = 9AA6D458AA9500633AE75B48B31578C8;
+			remoteInfo = "Pods-SnapchatKit_Tests-Mantle";
+		};
+		39CA70B1A1DEAF4702193C1CAD4DC9F7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C1D54FDF44B8FE5D2AFF98BECDA3BEF0;
+			remoteInfo = "Pods-SnapchatKit-OSX-SnapchatKit";
+		};
+		5CB6A6D98D721D2ECE56382BA98DFDF7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9AA6D458AA9500633AE75B48B31578C8;
+			remoteInfo = "Pods-SnapchatKit_Tests-Mantle";
+		};
+		61690EC51D3B1E374DB1D3D0CB4E969D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CFBBDE16B24F23D7D06648FFAAF08EA0;
 			remoteInfo = "Pods-SnapchatKit-OSX-Mantle";
+		};
+		66BD34445487482ABE102641D4F513E9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CFBBDE16B24F23D7D06648FFAAF08EA0;
+			remoteInfo = "Pods-SnapchatKit-OSX-Mantle";
+		};
+		860FED3CFA68D5F356951FC868117F94 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6CB26C3AF4D302C46F6AC967036A696C;
+			remoteInfo = "Pods-SnapchatKit_Example-SnapchatKit";
+		};
+		D4BB82AC6978E3FB574E83918FBCDAA1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 89CDA72857EF513C2576EBAF8DC1B118;
+			remoteInfo = "Pods-SnapchatKit_Example-Mantle";
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		00F7E64375D906AADEEBE012 /* SKSnapOptions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKSnapOptions.m; sourceTree = "<group>"; };
-		016FE40D9852B7D7C16202BB /* Pods-SnapchatKit_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-SnapchatKit_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
-		01A3D282D76F2492158972A9 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		022825FCF2BAF08416579518 /* SKSimpleUser.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKSimpleUser.m; sourceTree = "<group>"; };
-		0352130AD3816023F8068ECA /* SKClient+Stories.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SKClient+Stories.h"; sourceTree = "<group>"; };
-		0746351ADCB0B21FE32B2E85 /* MessageBuilder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MessageBuilder.h; sourceTree = "<group>"; };
-		0A8FA92E556068A6CE1CCE16 /* ioapi.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; path = ioapi.c; sourceTree = "<group>"; };
-		0AA75375F2F52C8E60ABBCCB /* metamacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = metamacros.h; path = Mantle/extobjc/metamacros.h; sourceTree = "<group>"; };
-		0B18B08E9AA35CE5DC2A6970 /* SnapchatKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SnapchatKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		0BB3F424212EAD00F4624235 /* Pods-SnapchatKit_Tests-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SnapchatKit_Tests-environment.h"; sourceTree = "<group>"; };
-		0F89D17AA09083FFEC8C72CF /* CodedOutputStream.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = CodedOutputStream.h; sourceTree = "<group>"; };
-		11064E9E55CF944B7E747575 /* Utilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = Utilities.m; sourceTree = "<group>"; };
-		116CA5F3E415255E8D2A4C6B /* GeneratedMessageBuilder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = GeneratedMessageBuilder.h; sourceTree = "<group>"; };
-		1198650DD0951EF6D7936CB7 /* SKStoryOptions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKStoryOptions.h; sourceTree = "<group>"; };
-		123AA38787CE03C6CCCD59EF /* SKSnapResponse.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKSnapResponse.m; sourceTree = "<group>"; };
-		138BBC48171ED63193A16737 /* Pods-SnapchatKit_Tests-Mantle-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-SnapchatKit_Tests-Mantle-umbrella.h"; path = "../Pods-SnapchatKit_Tests-Mantle/Pods-SnapchatKit_Tests-Mantle-umbrella.h"; sourceTree = "<group>"; };
-		150E0D42F8ADD64688F5FF77 /* SKNewConversation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKNewConversation.m; sourceTree = "<group>"; };
-		1628AB0CEF6EECD372AA222B /* ExtensionRegistry.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ExtensionRegistry.m; sourceTree = "<group>"; };
-		17D0AA7AA0EA6CC242B330F9 /* SKClient+Stories.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SKClient+Stories.m"; sourceTree = "<group>"; };
-		1873516313DE12A18B441976 /* Mantle.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mantle.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		19686F6CA6E05777DCB4F394 /* Pods-SnapchatKit-OSX-Mantle-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SnapchatKit-OSX-Mantle-prefix.pch"; sourceTree = "<group>"; };
-		1B58BC08B10D15123B320AFD /* MTLModel+NSCoding.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "MTLModel+NSCoding.m"; path = "Mantle/MTLModel+NSCoding.m"; sourceTree = "<group>"; };
-		1CE06043D4DC81317EE540DE /* SKLocation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKLocation.h; sourceTree = "<group>"; };
-		1D05C23668A6E8B4DEF4111C /* Pods-SnapchatKit-OSX-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SnapchatKit-OSX-environment.h"; sourceTree = "<group>"; };
-		1D4A7091C6DE37C14EBE847D /* EXTScope.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTScope.h; path = Mantle/extobjc/EXTScope.h; sourceTree = "<group>"; };
-		1DD52DE4A9AAD6E3A69EB894 /* UnknownFieldSet.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = UnknownFieldSet.m; sourceTree = "<group>"; };
-		1EDA4E519FE1136F8E6159C2 /* NSDictionary+SnapchatKit.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+SnapchatKit.m"; sourceTree = "<group>"; };
-		20C9C55D2ED86B58CAF02D6C /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../Pods-SnapchatKit_Tests-Mantle/Info.plist"; sourceTree = "<group>"; };
-		215676CE55DE6C39627F6595 /* Pods-SnapchatKit_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SnapchatKit_Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		21D7027B0107A87B98B269DD /* SKCashTransaction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKCashTransaction.m; sourceTree = "<group>"; };
-		29CFD017511A61FDEEFEF7FB /* CodedInputStream.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = CodedInputStream.h; sourceTree = "<group>"; };
-		2B450E93CAE222E73572A5BA /* ObjectivecDescriptor.pb.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ObjectivecDescriptor.pb.m; sourceTree = "<group>"; };
-		2B7029FB4531206FAF1E971E /* SKMessage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKMessage.h; sourceTree = "<group>"; };
-		2BD6662AFDE6D73BB17E57D0 /* SKLocation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKLocation.m; sourceTree = "<group>"; };
-		2C7985E1F9182ABE6BA9D3DE /* NSValueTransformer+MTLInversionAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValueTransformer+MTLInversionAdditions.m"; path = "Mantle/NSValueTransformer+MTLInversionAdditions.m"; sourceTree = "<group>"; };
-		2D2E53E10F5777B5687B8B84 /* Pods-SnapchatKit_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SnapchatKit_Tests.release.xcconfig"; sourceTree = "<group>"; };
-		2F5EAB4555DEC9D840E6827D /* Pods-SnapchatKit_Tests-SnapchatKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; name = "Pods-SnapchatKit_Tests-SnapchatKit.modulemap"; path = "../Pods-SnapchatKit_Tests-SnapchatKit/Pods-SnapchatKit_Tests-SnapchatKit.modulemap"; sourceTree = "<group>"; };
-		31201F9C36DCB8072A773375 /* SKClient+Chat.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SKClient+Chat.m"; sourceTree = "<group>"; };
-		31356904078AF381495527D2 /* Pods-SnapchatKit_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SnapchatKit_Example-umbrella.h"; sourceTree = "<group>"; };
-		3373DEC2ACD88C7B0D7E398D /* Pods-SnapchatKit_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-SnapchatKit_Tests-dummy.m"; sourceTree = "<group>"; };
-		346F22DD245A0A72527AE1C8 /* SKStory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKStory.m; sourceTree = "<group>"; };
-		34BDFDCAB53D1C3DF3D8B643 /* crypt.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = crypt.h; sourceTree = "<group>"; };
-		35EF0345D98539E68C6DCCF0 /* AbstractMessageBuilder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = AbstractMessageBuilder.m; sourceTree = "<group>"; };
-		36535381D153E491915E5B96 /* zip.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = zip.h; sourceTree = "<group>"; };
-		366DC11AD62752B2C3E9393B /* unzip.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = unzip.h; sourceTree = "<group>"; };
-		367E68898317851726B59744 /* unzip.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; path = unzip.c; sourceTree = "<group>"; };
-		36ECBA089FD3718EDC1195C0 /* SKClient+Account.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SKClient+Account.m"; sourceTree = "<group>"; };
-		3897135FC4BE5D51EF3A68BF /* Pods-SnapchatKit_Tests-Mantle-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-SnapchatKit_Tests-Mantle-prefix.pch"; path = "../Pods-SnapchatKit_Tests-Mantle/Pods-SnapchatKit_Tests-Mantle-prefix.pch"; sourceTree = "<group>"; };
-		3BE6AF84EBA6D92BCE5C7636 /* TextFormat.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TextFormat.h; sourceTree = "<group>"; };
-		3EA20DEDFF58DCEC2DCACEEF /* Pods-SnapchatKit_Example-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SnapchatKit_Example-environment.h"; sourceTree = "<group>"; };
-		3F6C4F7854C482C05E42ED2B /* SKStoryCollection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKStoryCollection.m; sourceTree = "<group>"; };
-		3F736D4FA1DF5519A4A7088E /* Pods-SnapchatKit_Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-SnapchatKit_Tests.modulemap"; sourceTree = "<group>"; };
-		40971082BAA72F1F1EDAF695 /* AbstractMessageBuilder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = AbstractMessageBuilder.h; sourceTree = "<group>"; };
-		415D7284CB388E44D7F0FD42 /* Pods-SnapchatKit_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SnapchatKit_Example-acknowledgements.plist"; sourceTree = "<group>"; };
-		445678C61FB42AB9BD4D4D49 /* SKStoryNote.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKStoryNote.m; sourceTree = "<group>"; };
-		44845973A3A65096EB9FCC26 /* Pods-SnapchatKit_Example-Mantle.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SnapchatKit_Example-Mantle.xcconfig"; path = "../Pods-SnapchatKit_Example-Mantle/Pods-SnapchatKit_Example-Mantle.xcconfig"; sourceTree = "<group>"; };
-		449CC84B46793A16723EFAF3 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		468545A3D0F59F8EB5EC8623 /* SKClient+Account.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SKClient+Account.h"; sourceTree = "<group>"; };
-		4693BF7FBC62DA24F8CB6153 /* NSArray+SnapchatKit.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSArray+SnapchatKit.m"; sourceTree = "<group>"; };
-		4762A159FAA8CE845790577D /* NSArray+MTLManipulationAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSArray+MTLManipulationAdditions.h"; path = "Mantle/NSArray+MTLManipulationAdditions.h"; sourceTree = "<group>"; };
-		480232BB439E70191B69829A /* SKThing.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKThing.m; sourceTree = "<group>"; };
-		48071AFDE030FA44AF31654C /* Pods-SnapchatKit-OSX-Mantle.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SnapchatKit-OSX-Mantle.xcconfig"; sourceTree = "<group>"; };
-		49123558EC733737D4B7828B /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		4A08CC8E2AC99F2D225D628E /* SKBlob.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKBlob.h; sourceTree = "<group>"; };
-		4A09000891FE155F04E84237 /* NSDictionary+MTLManipulationAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSDictionary+MTLManipulationAdditions.m"; path = "Mantle/NSDictionary+MTLManipulationAdditions.m"; sourceTree = "<group>"; };
-		4D47212A4D9D5CE2BCB35089 /* Pods-SnapchatKit_Example-Mantle-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-SnapchatKit_Example-Mantle-prefix.pch"; path = "../Pods-SnapchatKit_Example-Mantle/Pods-SnapchatKit_Example-Mantle-prefix.pch"; sourceTree = "<group>"; };
-		4F32C4F587D89334A3BCBE23 /* AbstractMessage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = AbstractMessage.h; sourceTree = "<group>"; };
-		4F9C3899FAAC648953D8E96C /* Pods-SnapchatKit_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-SnapchatKit_Example-dummy.m"; sourceTree = "<group>"; };
-		4FF03725A1FBD01F3B54D410 /* SKSnap.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKSnap.h; sourceTree = "<group>"; };
-		502600138FD1162EC5F0E835 /* TextFormat.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TextFormat.m; sourceTree = "<group>"; };
-		503F98FEAAC39B02E3C4B2F1 /* Pods-SnapchatKit-OSX-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SnapchatKit-OSX-umbrella.h"; sourceTree = "<group>"; };
-		515761136CC4D2DA31CBDCCE /* EXTRuntimeExtensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTRuntimeExtensions.h; path = Mantle/extobjc/EXTRuntimeExtensions.h; sourceTree = "<group>"; };
-		53233F46F0A7FEE3BAB2F5F0 /* Mantle.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mantle.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		53358FC1AF684CCB6202172F /* Descriptor.pb.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = Descriptor.pb.m; sourceTree = "<group>"; };
-		53E643E4011CFF791437DE5C /* ConcreteExtensionField.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ConcreteExtensionField.h; sourceTree = "<group>"; };
-		5458179AFBA3B4551E76D06C /* NSArray+SnapchatKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSArray+SnapchatKit.h"; sourceTree = "<group>"; };
-		549084617E4D5DCBD4ED4B0E /* Field.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = Field.m; sourceTree = "<group>"; };
-		57779D995D4EED4517C14162 /* ExtensionField.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ExtensionField.h; sourceTree = "<group>"; };
-		57804134FAC62DB389FA867E /* SKConversation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKConversation.h; sourceTree = "<group>"; };
-		5846DBD972BB2E4E8516487A /* SSZipArchive.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SSZipArchive.h; sourceTree = "<group>"; };
-		59D88C1F1755D563CB421C63 /* Pods_SnapchatKit_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SnapchatKit_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		5A4E677C0A6B08357EDE38B3 /* SnapchatKit-Constants.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SnapchatKit-Constants.h"; sourceTree = "<group>"; };
-		5BCC3D97332ACAEB112939B8 /* Pods_SnapchatKit_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SnapchatKit_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		5CC5CD60538DCDD4998B4E9D /* SKStoryNote.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKStoryNote.h; sourceTree = "<group>"; };
-		5D2A3B038ECCCA6DF6D3B46B /* CodedInputStream.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = CodedInputStream.m; sourceTree = "<group>"; };
-		5D76E52DF8BD7923ED927F40 /* Pods-SnapchatKit_Tests-SnapchatKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-SnapchatKit_Tests-SnapchatKit-prefix.pch"; path = "../Pods-SnapchatKit_Tests-SnapchatKit/Pods-SnapchatKit_Tests-SnapchatKit-prefix.pch"; sourceTree = "<group>"; };
-		5D85386BB83B94415BF95032 /* MutableExtensionRegistry.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MutableExtensionRegistry.h; sourceTree = "<group>"; };
-		5ED60ED9A8DEB4AF13B67CC8 /* SKUser.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKUser.h; sourceTree = "<group>"; };
-		5F3BDE1CAA9A717200841609 /* MTLTransformerErrorHandling.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MTLTransformerErrorHandling.m; path = Mantle/MTLTransformerErrorHandling.m; sourceTree = "<group>"; };
-		5F95A3237B10A013B18BFE81 /* Pods-SnapchatKit_Tests-Mantle.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SnapchatKit_Tests-Mantle.xcconfig"; path = "../Pods-SnapchatKit_Tests-Mantle/Pods-SnapchatKit_Tests-Mantle.xcconfig"; sourceTree = "<group>"; };
-		5F96C5D607778F1ABE0AA9A9 /* ForwardDeclarations.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ForwardDeclarations.h; sourceTree = "<group>"; };
-		5FFFD75623FB9218D73DE323 /* SKNewConversation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKNewConversation.h; sourceTree = "<group>"; };
-		605083736A08598B67B8C393 /* Pods-SnapchatKit-OSX-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-SnapchatKit-OSX-resources.sh"; sourceTree = "<group>"; };
-		6070FF02167CEB9FC7458D39 /* ExtendableMessage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ExtendableMessage.m; sourceTree = "<group>"; };
-		607499C80038757E311F8CA1 /* SKFoundFriend.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKFoundFriend.h; sourceTree = "<group>"; };
-		60CD411A1CA63391B2D224AB /* ProtocolBuffers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ProtocolBuffers.h; sourceTree = "<group>"; };
-		60FCE66689CCF5D0D0C98357 /* SnapchatKit-Constants.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SnapchatKit-Constants.m"; sourceTree = "<group>"; };
-		6532EFC9D4874C91D352A810 /* GeneratedMessage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = GeneratedMessage.m; sourceTree = "<group>"; };
-		676BE47EFE38F1493CD05107 /* ExtendableMessageBuilder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ExtendableMessageBuilder.m; sourceTree = "<group>"; };
-		679719A8EC9FC6E3B23D6151 /* ExtensionRegistry.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ExtensionRegistry.h; sourceTree = "<group>"; };
-		6CCF63F998DDD570BF396F60 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		6D2B9EB3ED194082F399A655 /* Pods-SnapchatKit-OSX-SnapchatKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-SnapchatKit-OSX-SnapchatKit-dummy.m"; sourceTree = "<group>"; };
-		6D9B66EB6E20F1C7D4AD8AA0 /* mztools.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = mztools.h; sourceTree = "<group>"; };
-		6DC7CD3FB2E0D2C3AF55E726 /* MutableExtensionRegistry.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MutableExtensionRegistry.m; sourceTree = "<group>"; };
-		6E2EF527D485AA3518965377 /* MTLTransformerErrorHandling.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MTLTransformerErrorHandling.h; path = Mantle/MTLTransformerErrorHandling.h; sourceTree = "<group>"; };
-		701146DB20AFF386866AA783 /* SKConversation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKConversation.m; sourceTree = "<group>"; };
-		7137BB5CBC818BC0E912BAE8 /* mztools.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; path = mztools.c; sourceTree = "<group>"; };
-		71577F1A49CF27CC9FA94074 /* UnknownFieldSetBuilder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = UnknownFieldSetBuilder.m; sourceTree = "<group>"; };
-		7183BB0F3292AEE43022E891 /* Bootstrap.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Bootstrap.h; sourceTree = "<group>"; };
-		73C1CB4E2FE3CF7FA2BAC175 /* Pods-SnapchatKit-OSX-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-SnapchatKit-OSX-dummy.m"; sourceTree = "<group>"; };
-		7403F5AB3E4BE3F53F76912D /* MTLValueTransformer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MTLValueTransformer.m; path = Mantle/MTLValueTransformer.m; sourceTree = "<group>"; };
-		7429D3F53C745B01ABB0BD0A /* Pods-SnapchatKit_Example-SnapchatKit-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-SnapchatKit_Example-SnapchatKit-umbrella.h"; path = "../Pods-SnapchatKit_Example-SnapchatKit/Pods-SnapchatKit_Example-SnapchatKit-umbrella.h"; sourceTree = "<group>"; };
-		74DA603BC9A41DF99F80FF9C /* NSString+SnapchatKit.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSString+SnapchatKit.m"; sourceTree = "<group>"; };
-		74DF1D6CA9D178F9CEE62E29 /* EXTScope.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXTScope.m; path = Mantle/extobjc/EXTScope.m; sourceTree = "<group>"; };
-		758F4DBFC84E4E8F2CDD9609 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../Pods-SnapchatKit_Example-SnapchatKit/Info.plist"; sourceTree = "<group>"; };
-		7604B3135534C28027647CD5 /* ConcreteExtensionField.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ConcreteExtensionField.m; sourceTree = "<group>"; };
-		76CC3491B3E0E22C56D21730 /* SKStory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKStory.h; sourceTree = "<group>"; };
-		7718349A691AC354D56DB602 /* NSArray+MTLManipulationAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSArray+MTLManipulationAdditions.m"; path = "Mantle/NSArray+MTLManipulationAdditions.m"; sourceTree = "<group>"; };
-		77332B89D8076A70739B6766 /* Pods-SnapchatKit_Example-Mantle.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; name = "Pods-SnapchatKit_Example-Mantle.modulemap"; path = "../Pods-SnapchatKit_Example-Mantle/Pods-SnapchatKit_Example-Mantle.modulemap"; sourceTree = "<group>"; };
-		79123DA71B89B29494D4B96D /* Pods-SnapchatKit-OSX-SnapchatKit.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SnapchatKit-OSX-SnapchatKit.xcconfig"; sourceTree = "<group>"; };
-		79892EA1B4AA29856078EE35 /* NSValueTransformer+MTLInversionAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValueTransformer+MTLInversionAdditions.h"; path = "Mantle/NSValueTransformer+MTLInversionAdditions.h"; sourceTree = "<group>"; };
-		7A2AAA454116F315A4C5A440 /* UnknownFieldSet.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = UnknownFieldSet.h; sourceTree = "<group>"; };
-		7B208DD3ECC3E9C53BF230B7 /* NSString+SnapchatKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSString+SnapchatKit.h"; sourceTree = "<group>"; };
-		7C7595A2095D32ABE35F10FE /* SKNearbyUser.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKNearbyUser.h; sourceTree = "<group>"; };
-		7D12E82F0CEA77B8F7DE1F9B /* RingBuffer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RingBuffer.m; sourceTree = "<group>"; };
-		7E47188605DEAD31B32CA84A /* SKClient.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKClient.m; sourceTree = "<group>"; };
-		7E8F65183882F17A3EE5BA5D /* SKSnap.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKSnap.m; sourceTree = "<group>"; };
-		7E9DDD2E3FB426249A82B662 /* Pods-SnapchatKit-OSX-SnapchatKit-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SnapchatKit-OSX-SnapchatKit-Private.xcconfig"; sourceTree = "<group>"; };
-		80B92F86F6383AF6373514DC /* Pods-SnapchatKit_Tests-SnapchatKit-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-SnapchatKit_Tests-SnapchatKit-umbrella.h"; path = "../Pods-SnapchatKit_Tests-SnapchatKit/Pods-SnapchatKit_Tests-SnapchatKit-umbrella.h"; sourceTree = "<group>"; };
-		815680717120B8611BBFE344 /* Pods-SnapchatKit_Tests-Mantle.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; name = "Pods-SnapchatKit_Tests-Mantle.modulemap"; path = "../Pods-SnapchatKit_Tests-Mantle/Pods-SnapchatKit_Tests-Mantle.modulemap"; sourceTree = "<group>"; };
-		81D3C8E6CF0E4B9EC98608DF /* ExtendableMessage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ExtendableMessage.h; sourceTree = "<group>"; };
-		825834A937BE3CAE02AB2EB9 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
-		832988A136ED728E71274116 /* Pods-SnapchatKit_Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-SnapchatKit_Example-resources.sh"; sourceTree = "<group>"; };
-		86036A1F4EC5319555943E4A /* Pods-SnapchatKit-OSX-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-SnapchatKit-OSX-acknowledgements.markdown"; sourceTree = "<group>"; };
-		864BFCBBD456ACC6691691E9 /* NSDictionary+MTLJSONKeyPath.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSDictionary+MTLJSONKeyPath.h"; path = "Mantle/NSDictionary+MTLJSONKeyPath.h"; sourceTree = "<group>"; };
-		87DC6A533A3CB69CFE3FC6D8 /* SKRequest.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKRequest.h; sourceTree = "<group>"; };
-		88B84931C4029CE138B1A35A /* SnapchatKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SnapchatKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		8ADC4AAB6A6ABCE48BCC5F84 /* SKSession.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKSession.h; sourceTree = "<group>"; };
-		8C23DFF2F44056D492331988 /* EXTRuntimeExtensions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXTRuntimeExtensions.m; path = Mantle/extobjc/EXTRuntimeExtensions.m; sourceTree = "<group>"; };
-		8CB417E7FA3A2177453C0458 /* SKAddedFriend.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKAddedFriend.m; sourceTree = "<group>"; };
-		8CC372A04E32E3B5A10B6683 /* SKFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKFilter.h; sourceTree = "<group>"; };
-		8D31FC75657D73CC0298E1EF /* Pods-SnapchatKit-OSX-Mantle-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-SnapchatKit-OSX-Mantle-dummy.m"; sourceTree = "<group>"; };
-		8D812C332409657DC581A5D4 /* Pods-SnapchatKit_Tests-SnapchatKit.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SnapchatKit_Tests-SnapchatKit.xcconfig"; path = "../Pods-SnapchatKit_Tests-SnapchatKit/Pods-SnapchatKit_Tests-SnapchatKit.xcconfig"; sourceTree = "<group>"; };
-		8E7CA746CADA1BDA8DFD79E9 /* NSDictionary+SnapchatKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+SnapchatKit.h"; sourceTree = "<group>"; };
-		8EE2DC94841F1D57870388D7 /* MTLValueTransformer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MTLValueTransformer.h; path = Mantle/MTLValueTransformer.h; sourceTree = "<group>"; };
-		8F10C5B94F9F3FF19B6B285D /* ExtendableMessageBuilder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ExtendableMessageBuilder.h; sourceTree = "<group>"; };
-		8FD3C16495412F844A298EA3 /* SKSharedStoryDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKSharedStoryDescription.h; sourceTree = "<group>"; };
-		90BEF1EF981624D8235EE9E6 /* Message.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Message.h; sourceTree = "<group>"; };
-		90D507AAE40D2CEED0D36687 /* CodedOutputStream.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = CodedOutputStream.m; sourceTree = "<group>"; };
-		90D6B47A535307DE73D6422E /* Pods-SnapchatKit_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SnapchatKit_Example.release.xcconfig"; sourceTree = "<group>"; };
-		90F41EB5F4D4C93EFA06977B /* SKUserStory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKUserStory.m; sourceTree = "<group>"; };
-		91FD8FDCB1EF8E5342243FB7 /* WireFormat.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = WireFormat.h; sourceTree = "<group>"; };
-		92E7239EFF6E75EA9F6F3561 /* SnapchatKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SnapchatKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		9580C868D4BD628B16033847 /* SSZipArchive.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SSZipArchive.m; sourceTree = "<group>"; };
-		9A0021AF19BB03BE8068C892 /* ioapi.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ioapi.h; sourceTree = "<group>"; };
-		9A37A0F5E40E5D3D0B42D25A /* Pods-SnapchatKit_Example-Mantle-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-SnapchatKit_Example-Mantle-umbrella.h"; path = "../Pods-SnapchatKit_Example-Mantle/Pods-SnapchatKit_Example-Mantle-umbrella.h"; sourceTree = "<group>"; };
-		9B86948413F2BA125B8C7D03 /* SKUser.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKUser.m; sourceTree = "<group>"; };
-		9BE3B4334F276CA5FE417047 /* NSData+SnapchatKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSData+SnapchatKit.h"; sourceTree = "<group>"; };
-		9EBA09F0C92556545D654BDD /* MTLReflection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MTLReflection.h; path = Mantle/MTLReflection.h; sourceTree = "<group>"; };
-		A00A37246F318C66CDCFC569 /* Pods-SnapchatKit-OSX-Mantle-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SnapchatKit-OSX-Mantle-Private.xcconfig"; sourceTree = "<group>"; };
-		A00BAA82C52FA3361AD62FC3 /* Pods-SnapchatKit_Example-SnapchatKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; name = "Pods-SnapchatKit_Example-SnapchatKit.modulemap"; path = "../Pods-SnapchatKit_Example-SnapchatKit/Pods-SnapchatKit_Example-SnapchatKit.modulemap"; sourceTree = "<group>"; };
-		A1ACEF81DAC35F3667E86099 /* SKClient+Friends.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SKClient+Friends.m"; sourceTree = "<group>"; };
-		A22019B34FF3D28330B16DF5 /* GeneratedMessageBuilder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = GeneratedMessageBuilder.m; sourceTree = "<group>"; };
-		A404DFA42617BDF6EDEE50D3 /* Pods-SnapchatKit_Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-SnapchatKit_Tests-frameworks.sh"; sourceTree = "<group>"; };
-		A41479F50FBF748BB5D19D50 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		A6E7159BC244D52AEB941180 /* Pods-SnapchatKit_Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SnapchatKit_Tests-acknowledgements.plist"; sourceTree = "<group>"; };
-		A766840A3FA15875DD115B84 /* SKAddedFriend.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKAddedFriend.h; sourceTree = "<group>"; };
-		A7C23396CBC972AE283C6179 /* Pods-SnapchatKit_Example-Mantle-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-SnapchatKit_Example-Mantle-dummy.m"; path = "../Pods-SnapchatKit_Example-Mantle/Pods-SnapchatKit_Example-Mantle-dummy.m"; sourceTree = "<group>"; };
-		A91683F22FB4EF562527CCF8 /* NSError+MTLModelException.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSError+MTLModelException.h"; path = "Mantle/NSError+MTLModelException.h"; sourceTree = "<group>"; };
-		A9FBC3803D641A8AF3A1A033 /* EXTKeyPathCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTKeyPathCoding.h; path = Mantle/extobjc/EXTKeyPathCoding.h; sourceTree = "<group>"; };
-		AA149B4D211D5124D4002334 /* RingBuffer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = RingBuffer.h; sourceTree = "<group>"; };
-		AA6CFFAEAE05991AB9B2A783 /* Pods-SnapchatKit-OSX-SnapchatKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-SnapchatKit-OSX-SnapchatKit.modulemap"; sourceTree = "<group>"; };
-		AACC20FB1D0DE81D97FC7F46 /* NSObject+MTLComparisonAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+MTLComparisonAdditions.h"; path = "Mantle/NSObject+MTLComparisonAdditions.h"; sourceTree = "<group>"; };
-		AAEE9103C8BA8123534B7278 /* UnknownFieldSetBuilder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = UnknownFieldSetBuilder.h; sourceTree = "<group>"; };
-		ABEFC3F1ABD4E8AFE75B8DF3 /* Pods-SnapchatKit_Example-SnapchatKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-SnapchatKit_Example-SnapchatKit-dummy.m"; path = "../Pods-SnapchatKit_Example-SnapchatKit/Pods-SnapchatKit_Example-SnapchatKit-dummy.m"; sourceTree = "<group>"; };
-		AD3C9AC8DBADBCAB8DA86DA8 /* SKClient.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKClient.h; sourceTree = "<group>"; };
-		AD9CE5C7E8B71B7A717BF7CF /* SKStoryUpdater.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKStoryUpdater.h; sourceTree = "<group>"; };
-		B0A48052AEB65F7B647DB473 /* MTLReflection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MTLReflection.m; path = Mantle/MTLReflection.m; sourceTree = "<group>"; };
-		B18A7FA8139D76C64101D79E /* Pods-SnapchatKit-OSX-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SnapchatKit-OSX-acknowledgements.plist"; sourceTree = "<group>"; };
-		B248168DD03CA01E639F3B0F /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		B2CC18BCB4D507891F83A273 /* Pods-SnapchatKit_Tests-SnapchatKit-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SnapchatKit_Tests-SnapchatKit-Private.xcconfig"; path = "../Pods-SnapchatKit_Tests-SnapchatKit/Pods-SnapchatKit_Tests-SnapchatKit-Private.xcconfig"; sourceTree = "<group>"; };
-		B3034C9C4729EFDDAF24276C /* SKFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKFilter.m; sourceTree = "<group>"; };
-		B359AC7608C8680235607B64 /* MutableField.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MutableField.h; sourceTree = "<group>"; };
-		B4399388D431562C74758070 /* NSDictionary+MTLMappingAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSDictionary+MTLMappingAdditions.m"; path = "Mantle/NSDictionary+MTLMappingAdditions.m"; sourceTree = "<group>"; };
-		B475512FAECA1EDC22AF0197 /* SKStoryCollection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKStoryCollection.h; sourceTree = "<group>"; };
-		B5F8AE9D9CC92F9D2639DE69 /* Descriptor.pb.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Descriptor.pb.h; sourceTree = "<group>"; };
-		B651D104642825FF7BC7098D /* Pods-SnapchatKit-OSX.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SnapchatKit-OSX.debug.xcconfig"; sourceTree = "<group>"; };
-		B71A42ED9C9A282E7A4B4542 /* SKFoundFriend.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKFoundFriend.m; sourceTree = "<group>"; };
-		B72804C93C3C7282FF48DBB1 /* Pods-SnapchatKit-OSX.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-SnapchatKit-OSX.modulemap"; sourceTree = "<group>"; };
-		B74CCA0F13F010EF6C5F3108 /* NSDictionary+MTLMappingAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSDictionary+MTLMappingAdditions.h"; path = "Mantle/NSDictionary+MTLMappingAdditions.h"; sourceTree = "<group>"; };
-		B758A255FCB12557BF687DBF /* Utilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Utilities.h; sourceTree = "<group>"; };
-		B82E05A3E46B11BD9BF8921D /* SKClient+Device.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SKClient+Device.m"; sourceTree = "<group>"; };
-		B97745F20B56DFE00D4434D7 /* SKSnapOptions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKSnapOptions.h; sourceTree = "<group>"; };
-		B9DAF269D11078378EFFAF9F /* Pods-SnapchatKit-OSX-Mantle.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-SnapchatKit-OSX-Mantle.modulemap"; sourceTree = "<group>"; };
-		B9E73BE37CE97F84CA411252 /* Mantle.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mantle.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		BC234E8391D1425381C05523 /* Attestation.pb.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Attestation.pb.h; sourceTree = "<group>"; };
-		BE23F92F0AF5FAC9B46B1080 /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		BFA49567896C833E44B3C4A1 /* SKSimpleUser.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKSimpleUser.h; sourceTree = "<group>"; };
-		C0AA124AA5FC698AF6045124 /* Pods-SnapchatKit_Example-SnapchatKit.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SnapchatKit_Example-SnapchatKit.xcconfig"; path = "../Pods-SnapchatKit_Example-SnapchatKit/Pods-SnapchatKit_Example-SnapchatKit.xcconfig"; sourceTree = "<group>"; };
-		C3CACC2CC8A6328EED00102F /* Pods-SnapchatKit_Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SnapchatKit_Tests-umbrella.h"; sourceTree = "<group>"; };
-		C49BF5D2D648742FCBBC6433 /* MTLModel+NSCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "MTLModel+NSCoding.h"; path = "Mantle/MTLModel+NSCoding.h"; sourceTree = "<group>"; };
-		C55205D98ACA2596E3A93000 /* AbstractMessage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = AbstractMessage.m; sourceTree = "<group>"; };
-		C59B176424A659FA44EB301D /* SKClient+Snaps.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SKClient+Snaps.m"; sourceTree = "<group>"; };
-		C5DE13676C268EA621449922 /* Pods-SnapchatKit_Tests-Mantle-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SnapchatKit_Tests-Mantle-Private.xcconfig"; path = "../Pods-SnapchatKit_Tests-Mantle/Pods-SnapchatKit_Tests-Mantle-Private.xcconfig"; sourceTree = "<group>"; };
-		C72DBD7A6DA7655074E62D29 /* SKBlob.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKBlob.m; sourceTree = "<group>"; };
-		C89FFC35CCC557BCAB64BE65 /* Pods-SnapchatKit_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-SnapchatKit_Example-frameworks.sh"; sourceTree = "<group>"; };
-		C90C099E43248D72169A5B0B /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValueTransformer+MTLPredefinedTransformerAdditions.m"; path = "Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m"; sourceTree = "<group>"; };
-		C91FA387C6BC12DFCEC16B08 /* Pods-SnapchatKit-OSX-Mantle-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SnapchatKit-OSX-Mantle-umbrella.h"; sourceTree = "<group>"; };
-		CD40B957499A960C0F251F7A /* MTLJSONAdapter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MTLJSONAdapter.h; path = Mantle/MTLJSONAdapter.h; sourceTree = "<group>"; };
-		CD7CF6D3EDE14721A9FA183B /* SKClient+Friends.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SKClient+Friends.h"; sourceTree = "<group>"; };
-		CE41466A7EA286DF1DA66939 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../Pods-SnapchatKit_Example-Mantle/Info.plist"; sourceTree = "<group>"; };
-		D14F237EC025DFF27B83C274 /* PBArray.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PBArray.m; sourceTree = "<group>"; };
-		D1A0970111F805282AEC6CAD /* PBArray.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PBArray.h; sourceTree = "<group>"; };
-		D3CB8B66AC28E9296B200E45 /* SnapchatKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SnapchatKit.h; sourceTree = "<group>"; };
-		D62E5A585E176727B114DBF8 /* NSDictionary+MTLManipulationAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSDictionary+MTLManipulationAdditions.h"; path = "Mantle/NSDictionary+MTLManipulationAdditions.h"; sourceTree = "<group>"; };
-		DA1D849137C33690C52103DA /* Pods-SnapchatKit_Tests-Mantle-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-SnapchatKit_Tests-Mantle-dummy.m"; path = "../Pods-SnapchatKit_Tests-Mantle/Pods-SnapchatKit_Tests-Mantle-dummy.m"; sourceTree = "<group>"; };
-		DA7D052FF7B5D4F9FAB6264F /* NSData+SnapchatKit.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSData+SnapchatKit.m"; sourceTree = "<group>"; };
-		DBA9AE1A1E5EF9F254B40F05 /* Pods-SnapchatKit-OSX-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-SnapchatKit-OSX-frameworks.sh"; sourceTree = "<group>"; };
-		DC1C419D734F0A8C9DA47458 /* Pods-SnapchatKit_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-SnapchatKit_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		DC77D677392F90E40D0F2B2F /* SKNearbyUser.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKNearbyUser.m; sourceTree = "<group>"; };
-		DCDA93F546D12297EA015005 /* SKClient+Discover.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SKClient+Discover.m"; sourceTree = "<group>"; };
-		DEFFD560FDB1107DBA31BD0C /* Pods-SnapchatKit_Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-SnapchatKit_Tests-resources.sh"; sourceTree = "<group>"; };
-		DF748A340BF9306E32B97ED3 /* Pods-SnapchatKit_Example-Mantle-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SnapchatKit_Example-Mantle-Private.xcconfig"; path = "../Pods-SnapchatKit_Example-Mantle/Pods-SnapchatKit_Example-Mantle-Private.xcconfig"; sourceTree = "<group>"; };
-		DFEB6906EBD2B7C0F34E76B4 /* Pods-SnapchatKit_Example-SnapchatKit-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SnapchatKit_Example-SnapchatKit-Private.xcconfig"; path = "../Pods-SnapchatKit_Example-SnapchatKit/Pods-SnapchatKit_Example-SnapchatKit-Private.xcconfig"; sourceTree = "<group>"; };
-		E0BE5272169F0ABBBAE1A7C3 /* Pods-SnapchatKit-OSX-SnapchatKit-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SnapchatKit-OSX-SnapchatKit-umbrella.h"; sourceTree = "<group>"; };
-		E143F32D6FBEF9E2E0AD119E /* Mantle.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Mantle.h; path = Mantle/Mantle.h; sourceTree = "<group>"; };
-		E1DC65C5D930DE74DF698A83 /* NSDictionary+MTLJSONKeyPath.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSDictionary+MTLJSONKeyPath.m"; path = "Mantle/NSDictionary+MTLJSONKeyPath.m"; sourceTree = "<group>"; };
-		E214FDD4BCEA0508B7346283 /* Pods-SnapchatKit_Example-SnapchatKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-SnapchatKit_Example-SnapchatKit-prefix.pch"; path = "../Pods-SnapchatKit_Example-SnapchatKit/Pods-SnapchatKit_Example-SnapchatKit-prefix.pch"; sourceTree = "<group>"; };
-		E258F52BF2199045E866A6F0 /* SKSession.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKSession.m; sourceTree = "<group>"; };
-		E2FB4A4D3FF57F7B9A0C482C /* MTLModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MTLModel.m; path = Mantle/MTLModel.m; sourceTree = "<group>"; };
-		E3F90C74F6B4513DB6B80D92 /* NSObject+MTLComparisonAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+MTLComparisonAdditions.m"; path = "Mantle/NSObject+MTLComparisonAdditions.m"; sourceTree = "<group>"; };
-		E4C3F559B4946C7AB8AFA8A4 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../Pods-SnapchatKit_Tests-SnapchatKit/Info.plist"; sourceTree = "<group>"; };
-		E4C61B7D956E59989273650A /* Attestation.pb.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = Attestation.pb.m; sourceTree = "<group>"; };
-		E4DD12BC1374B1D0F8A542E6 /* SKClient+Snaps.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SKClient+Snaps.h"; sourceTree = "<group>"; };
-		E51DD16CB1A38D500A0D81DF /* Pods-SnapchatKit_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-SnapchatKit_Example.modulemap"; sourceTree = "<group>"; };
-		E6DCF7D3DF29FF7F743F3642 /* WireFormat.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = WireFormat.m; sourceTree = "<group>"; };
-		E85AA3FDA1B47E649DCA1DD1 /* NSValueTransformer+MTLPredefinedTransformerAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValueTransformer+MTLPredefinedTransformerAdditions.h"; path = "Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.h"; sourceTree = "<group>"; };
-		E9AEA239EC2FAC0FBDB45EE7 /* Pods-SnapchatKit_Tests-SnapchatKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-SnapchatKit_Tests-SnapchatKit-dummy.m"; path = "../Pods-SnapchatKit_Tests-SnapchatKit/Pods-SnapchatKit_Tests-SnapchatKit-dummy.m"; sourceTree = "<group>"; };
-		EB8FB810CD3E9AF9303846D2 /* SKMessage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKMessage.m; sourceTree = "<group>"; };
-		EB9C7549B766712AC0F5F9F7 /* zip.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; path = zip.c; sourceTree = "<group>"; };
-		EBAC7CF928D68AD3EE37FB4D /* SKCashTransaction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKCashTransaction.h; sourceTree = "<group>"; };
-		EDDC5E23649AF7A1E0BB82E8 /* NSError+MTLModelException.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSError+MTLModelException.m"; path = "Mantle/NSError+MTLModelException.m"; sourceTree = "<group>"; };
-		F026B71E625916EE223E04FF /* Pods-SnapchatKit-OSX-SnapchatKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SnapchatKit-OSX-SnapchatKit-prefix.pch"; sourceTree = "<group>"; };
-		F128C2CF8C3AF119EF791658 /* SKSnapResponse.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKSnapResponse.h; sourceTree = "<group>"; };
-		F1D451149D1CCB912DFC59DA /* SKSharedStoryDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKSharedStoryDescription.m; sourceTree = "<group>"; };
-		F1DE6FC4BDB289A1735EC820 /* SKClient+Device.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SKClient+Device.h"; sourceTree = "<group>"; };
-		F275805645C8FED83BC58CE7 /* MTLJSONAdapter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MTLJSONAdapter.m; path = Mantle/MTLJSONAdapter.m; sourceTree = "<group>"; };
-		F2DB5DC9CB68ABDBF1C8F8AE /* SKStoryUpdater.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKStoryUpdater.m; sourceTree = "<group>"; };
-		F347842C5587B36F931554EC /* Field.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Field.h; sourceTree = "<group>"; };
-		F54BFB630D034BFBDD1AD679 /* Pods_SnapchatKit_OSX.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SnapchatKit_OSX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		F552284B16EA501247330C10 /* SKClient+Chat.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SKClient+Chat.h"; sourceTree = "<group>"; };
-		F6310B7A8D4CCC215C36FC42 /* GeneratedMessage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = GeneratedMessage.h; sourceTree = "<group>"; };
-		F6E2FD20F292E5625A4FE3BE /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		F9218CE3AF46DF110AC1FC93 /* ObjectivecDescriptor.pb.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ObjectivecDescriptor.pb.h; sourceTree = "<group>"; };
-		F9884910EFC1C632C163D4E9 /* SKStoryOptions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKStoryOptions.m; sourceTree = "<group>"; };
-		FAA670771CDCBC81331CC379 /* Pods-SnapchatKit_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SnapchatKit_Example.debug.xcconfig"; sourceTree = "<group>"; };
-		FB3E8A3A6BAD4DE5DB3BD0B3 /* SKRequest.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKRequest.m; sourceTree = "<group>"; };
-		FCA6532B428B695F70814807 /* SKClient+Discover.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SKClient+Discover.h"; sourceTree = "<group>"; };
-		FD60E62E28DCF876A104F0A7 /* SKUserStory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKUserStory.h; sourceTree = "<group>"; };
-		FE9A32571C6172EF5F9B70FD /* Pods-SnapchatKit-OSX.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SnapchatKit-OSX.release.xcconfig"; sourceTree = "<group>"; };
-		FEAB71425CD10455E6D75F28 /* MutableField.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MutableField.m; sourceTree = "<group>"; };
-		FF09072CAEC86883CBD1C5B7 /* MTLModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MTLModel.h; path = Mantle/MTLModel.h; sourceTree = "<group>"; };
-		FF2964E8E281C6629782BFF8 /* SKThing.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKThing.h; sourceTree = "<group>"; };
+		00655651C6BA81463B1F1AC19D408EFB /* ExtendableMessage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ExtendableMessage.h; sourceTree = "<group>"; };
+		01D3D233D27189A14C4D48B64946BEDC /* NSString+SnapchatKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSString+SnapchatKit.h"; sourceTree = "<group>"; };
+		01E0A94D80868EC6EA02AE1C229EAC5D /* ExtensionField.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ExtensionField.h; sourceTree = "<group>"; };
+		04365EC94A261DF5AA309962BFE4E7AA /* CodedInputStream.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = CodedInputStream.h; sourceTree = "<group>"; };
+		0460FB606CE25E0ACED9CBF453B53217 /* SKSession.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKSession.m; sourceTree = "<group>"; };
+		0595D336EA25C014342530119C843CA6 /* SSZipArchive.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SSZipArchive.m; sourceTree = "<group>"; };
+		06373D743A4B8735559065DB34A4D3CF /* MTLModel+NSCoding.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "MTLModel+NSCoding.m"; path = "Mantle/MTLModel+NSCoding.m"; sourceTree = "<group>"; };
+		06531AAEF120FF70E927F40F0A61C49D /* NSArray+MTLManipulationAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSArray+MTLManipulationAdditions.h"; path = "Mantle/NSArray+MTLManipulationAdditions.h"; sourceTree = "<group>"; };
+		06B966634B688674E5961D625443E7E4 /* ExtensionRegistry.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ExtensionRegistry.h; sourceTree = "<group>"; };
+		07EAD9F6F9FA6CF821F00410E5793C55 /* AbstractMessage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = AbstractMessage.h; sourceTree = "<group>"; };
+		0A0F9C65CF3106FAC238CDC512FF51E2 /* SKCashTransaction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKCashTransaction.h; sourceTree = "<group>"; };
+		0A58A6FF946BC36ACBE07A96585CF06D /* Descriptor.pb.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Descriptor.pb.h; sourceTree = "<group>"; };
+		0C32BF92B3737BAB4293CB02DDD4B945 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0CA59E7E475EC4C780AB17196EE1F175 /* SKMessage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKMessage.h; sourceTree = "<group>"; };
+		0D7CCAAC157EB2E8A7F7A2290A48C89A /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
+		0E0A9E84EC29594B57D6036A4B137EB0 /* SKClient.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKClient.m; sourceTree = "<group>"; };
+		0FAFA003B01F71668975B806F52809BB /* Pods-SnapchatKit_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-SnapchatKit_Tests-dummy.m"; sourceTree = "<group>"; };
+		102BD1F037C4B0705E82FACAADBC648A /* SKSnapOptions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKSnapOptions.h; sourceTree = "<group>"; };
+		116F42487EDA4A9494C64821E46329F4 /* Pods-SnapchatKit_Tests-SnapchatKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; name = "Pods-SnapchatKit_Tests-SnapchatKit.modulemap"; path = "../Pods-SnapchatKit_Tests-SnapchatKit/Pods-SnapchatKit_Tests-SnapchatKit.modulemap"; sourceTree = "<group>"; };
+		14DA7638F179D4435E88DD761A6C54AF /* MTLReflection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MTLReflection.h; path = Mantle/MTLReflection.h; sourceTree = "<group>"; };
+		1508934AF2E2EE2B2C6287E8D0FD729E /* NSData+SnapchatKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSData+SnapchatKit.h"; sourceTree = "<group>"; };
+		151083D0F45656947CF1BAD22F86B9EE /* ExtendableMessageBuilder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ExtendableMessageBuilder.h; sourceTree = "<group>"; };
+		15787D58A018F7C163848E0EDEFFF2AB /* UnknownFieldSetBuilder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = UnknownFieldSetBuilder.m; sourceTree = "<group>"; };
+		1685FA7977E1A72A8CA039CF99A88D23 /* mztools.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = mztools.h; sourceTree = "<group>"; };
+		168FBDE79E6B224781B59DDED990CC1D /* SKAddedFriend.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKAddedFriend.m; sourceTree = "<group>"; };
+		184E597AA48D3822ECF8AEB2135DD087 /* metamacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = metamacros.h; path = Mantle/extobjc/metamacros.h; sourceTree = "<group>"; };
+		18B61B312FEA02DCE16514E7C4A29FBA /* MTLValueTransformer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MTLValueTransformer.h; path = Mantle/MTLValueTransformer.h; sourceTree = "<group>"; };
+		1B42D1B26321D48FD90287E53408FBAD /* Pods-SnapchatKit-OSX-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-SnapchatKit-OSX-frameworks.sh"; sourceTree = "<group>"; };
+		1CC8F0208F6B00877587B5E36CC3FCB9 /* Pods-SnapchatKit_Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-SnapchatKit_Tests-resources.sh"; sourceTree = "<group>"; };
+		1DC3BE7BB86B644F4B88640AA93A535C /* Pods-SnapchatKit-OSX-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SnapchatKit-OSX-umbrella.h"; sourceTree = "<group>"; };
+		1E3B442CA4C99021E31A08D4467D4203 /* AbstractMessage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = AbstractMessage.m; sourceTree = "<group>"; };
+		1FDC119599936009F4BBDAE2B034A189 /* NSValueTransformer+MTLInversionAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValueTransformer+MTLInversionAdditions.m"; path = "Mantle/NSValueTransformer+MTLInversionAdditions.m"; sourceTree = "<group>"; };
+		1FEA67B46E224685AD9C805D1A27E5D9 /* SKClient+Snaps.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SKClient+Snaps.h"; sourceTree = "<group>"; };
+		20F34E602ECE0E9952C0C9CC8D2E971A /* SKClient+Account.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SKClient+Account.m"; sourceTree = "<group>"; };
+		213011217E41F65FB2C0DC3B9627855E /* Pods-SnapchatKit-OSX-Mantle-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SnapchatKit-OSX-Mantle-prefix.pch"; sourceTree = "<group>"; };
+		21A864CDFDE11D41869495F647850956 /* MTLModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MTLModel.m; path = Mantle/MTLModel.m; sourceTree = "<group>"; };
+		2349A4CD323EDCB9F3445312B2F9489A /* SKStoryOptions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKStoryOptions.h; sourceTree = "<group>"; };
+		23C622E56337996E2A8713254F5BD246 /* SKClient+Chat.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SKClient+Chat.m"; sourceTree = "<group>"; };
+		25B50FC7D431013529A4EDF7982F6C0A /* SKLocation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKLocation.h; sourceTree = "<group>"; };
+		2A2690F1D5C31BAE7B8B476DDDD6C6B9 /* Pods-SnapchatKit_Example-SnapchatKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; name = "Pods-SnapchatKit_Example-SnapchatKit.modulemap"; path = "../Pods-SnapchatKit_Example-SnapchatKit/Pods-SnapchatKit_Example-SnapchatKit.modulemap"; sourceTree = "<group>"; };
+		2A537E793DA2330169541319E2AD1A2A /* SKNewConversation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKNewConversation.h; sourceTree = "<group>"; };
+		2B9085E7485D99346EF2A43B26F8F498 /* NSDictionary+MTLManipulationAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSDictionary+MTLManipulationAdditions.m"; path = "Mantle/NSDictionary+MTLManipulationAdditions.m"; sourceTree = "<group>"; };
+		2E8C22914F0D53BA79853BCCAE38D6A0 /* SKClient+Device.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SKClient+Device.h"; sourceTree = "<group>"; };
+		2E8E9BC41A16B11C168D078CD7578264 /* SnapchatKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SnapchatKit.h; sourceTree = "<group>"; };
+		2FADA08C22B41CD08228C4250C6B1A70 /* Utilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Utilities.h; sourceTree = "<group>"; };
+		2FBEB3B3FA6CC7990C60F15777A0090E /* SKSnapResponse.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKSnapResponse.h; sourceTree = "<group>"; };
+		2FDCF9C141D2B76551E065804EB72AF7 /* UnknownFieldSet.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = UnknownFieldSet.h; sourceTree = "<group>"; };
+		30966F6B3985DE33FEB91E8D08220629 /* MTLValueTransformer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MTLValueTransformer.m; path = Mantle/MTLValueTransformer.m; sourceTree = "<group>"; };
+		30F3816561C0672DD603262F36C61EB4 /* Bootstrap.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Bootstrap.h; sourceTree = "<group>"; };
+		31E2210149C81E3944A0BE1276CAC3A1 /* SKFoundFriend.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKFoundFriend.m; sourceTree = "<group>"; };
+		31F648378E994908BE3DEFFBD2CEB0CB /* RingBuffer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = RingBuffer.h; sourceTree = "<group>"; };
+		3337FCDB5568A74D24743FFB6337720A /* NSDictionary+SnapchatKit.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+SnapchatKit.m"; sourceTree = "<group>"; };
+		33BC1AF5B43B9D9D4E7129B4BC704208 /* Pods-SnapchatKit-OSX-Mantle.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SnapchatKit-OSX-Mantle.xcconfig"; sourceTree = "<group>"; };
+		3483A1EC7B5CF9FAD309261F6519CDF3 /* SKClient+Discover.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SKClient+Discover.m"; sourceTree = "<group>"; };
+		34BB852EFABC59BAFCA45806008FB3B0 /* Pods-SnapchatKit-OSX-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-SnapchatKit-OSX-dummy.m"; sourceTree = "<group>"; };
+		34D90DB5D3A0F6C9F52829680C3A220D /* SKStoryUpdater.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKStoryUpdater.m; sourceTree = "<group>"; };
+		3563C30BD97F4D46B5D201946CBD33E3 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		35985918E56AD9E0C441B57EF60B263E /* MTLModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MTLModel.h; path = Mantle/MTLModel.h; sourceTree = "<group>"; };
+		37186F3BDEF4361A87EE611FE929CFB9 /* ExtensionRegistry.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ExtensionRegistry.m; sourceTree = "<group>"; };
+		380466204986D63E3FD15C708124D907 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../Pods-SnapchatKit_Example-SnapchatKit/Info.plist"; sourceTree = "<group>"; };
+		39300C3939F3E500421A1E0654225D36 /* MutableExtensionRegistry.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MutableExtensionRegistry.m; sourceTree = "<group>"; };
+		3AC6595E4B0F1881632644CBC0879775 /* NSData+SnapchatKit.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSData+SnapchatKit.m"; sourceTree = "<group>"; };
+		3B5C08557F4B29304AA56AEC7D400D9F /* Pods-SnapchatKit_Tests-SnapchatKit.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SnapchatKit_Tests-SnapchatKit.xcconfig"; path = "../Pods-SnapchatKit_Tests-SnapchatKit/Pods-SnapchatKit_Tests-SnapchatKit.xcconfig"; sourceTree = "<group>"; };
+		3C0564DF17975EEE8CA66A75B382953E /* Pods-SnapchatKit_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-SnapchatKit_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
+		3F8EFE9CDCA52EC0CCBD1DF32DA061F4 /* SKSnapOptions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKSnapOptions.m; sourceTree = "<group>"; };
+		400621EB0B2F9F65897A439566594B63 /* Pods-SnapchatKit-OSX-Mantle-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SnapchatKit-OSX-Mantle-umbrella.h"; sourceTree = "<group>"; };
+		40340A31E91934BEB2CDCC541B6E29B8 /* Pods-SnapchatKit_Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-SnapchatKit_Example-resources.sh"; sourceTree = "<group>"; };
+		4149CC5EE78E849EAF5DEEFEE5B0AA66 /* ObjectivecDescriptor.pb.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ObjectivecDescriptor.pb.m; sourceTree = "<group>"; };
+		444ABAE227428925EDF5D132A91868E4 /* NSArray+SnapchatKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSArray+SnapchatKit.h"; sourceTree = "<group>"; };
+		452A825C1C9779653BE134C643213E98 /* NSObject+MTLComparisonAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+MTLComparisonAdditions.m"; path = "Mantle/NSObject+MTLComparisonAdditions.m"; sourceTree = "<group>"; };
+		456E2A07499A9C18F57AB9FC2613962F /* Pods-SnapchatKit-OSX-SnapchatKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-SnapchatKit-OSX-SnapchatKit.modulemap"; sourceTree = "<group>"; };
+		45A8B9B178D3D50255BED3D0FCB98A78 /* SKStoryCollection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKStoryCollection.h; sourceTree = "<group>"; };
+		463D5934C525845DDF6D4108DF174801 /* GeneratedMessageBuilder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = GeneratedMessageBuilder.m; sourceTree = "<group>"; };
+		4687F307C6DF4771125FACD4FEF41B6F /* WireFormat.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = WireFormat.m; sourceTree = "<group>"; };
+		46EF97B3320D5567B3CD996D681E6DB9 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		4825B54E2CDC5AA561EF544825F2A14F /* SKNearbyUser.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKNearbyUser.m; sourceTree = "<group>"; };
+		48D10AA8FB91C836871332883EEE8C79 /* SKSnap.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKSnap.h; sourceTree = "<group>"; };
+		4A4992617DD257BF87C19BD4E5A7D2A9 /* NSError+MTLModelException.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSError+MTLModelException.h"; path = "Mantle/NSError+MTLModelException.h"; sourceTree = "<group>"; };
+		4B6CEADD2D0C33311B5DF1F367E954A5 /* SKClient+Discover.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SKClient+Discover.h"; sourceTree = "<group>"; };
+		4CBC1007B50FB6D8D8CCC49C9AA3A908 /* SKClient+Account.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SKClient+Account.h"; sourceTree = "<group>"; };
+		4D2C9634F9F032DDCBE25B9910E30A5A /* ExtendableMessageBuilder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ExtendableMessageBuilder.m; sourceTree = "<group>"; };
+		4EBD65303E77D9EF88B73826511C216D /* ioapi.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; path = ioapi.c; sourceTree = "<group>"; };
+		4F0F9FF93E2C703E32F8511026F85347 /* zip.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; path = zip.c; sourceTree = "<group>"; };
+		4FE550472E08ABD8D5B741D1077F61BA /* unzip.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = unzip.h; sourceTree = "<group>"; };
+		523519361513D98C2F08E815B11DEF1B /* NSDictionary+SnapchatKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+SnapchatKit.h"; sourceTree = "<group>"; };
+		53DAF85FA8CA77FA6432DD4E4865FA28 /* NSDictionary+MTLMappingAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSDictionary+MTLMappingAdditions.m"; path = "Mantle/NSDictionary+MTLMappingAdditions.m"; sourceTree = "<group>"; };
+		54460D90C5A5A625598F1A72569A13B5 /* NSString+SnapchatKit.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSString+SnapchatKit.m"; sourceTree = "<group>"; };
+		5515DC27DAB5541F75B0AA3425061AAE /* SKUser.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKUser.m; sourceTree = "<group>"; };
+		5532B761F50A991D01D8E66810F650B5 /* SKMessage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKMessage.m; sourceTree = "<group>"; };
+		558B475B8EB352B7580B26A69BF74125 /* Pods-SnapchatKit_Tests-SnapchatKit-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-SnapchatKit_Tests-SnapchatKit-umbrella.h"; path = "../Pods-SnapchatKit_Tests-SnapchatKit/Pods-SnapchatKit_Tests-SnapchatKit-umbrella.h"; sourceTree = "<group>"; };
+		55BA9EA15DD7130BEC47C5B99EC9384A /* Descriptor.pb.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = Descriptor.pb.m; sourceTree = "<group>"; };
+		55E237D731C5ED759D5ED0585F50D2F3 /* Pods-SnapchatKit_Example-SnapchatKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-SnapchatKit_Example-SnapchatKit-prefix.pch"; path = "../Pods-SnapchatKit_Example-SnapchatKit/Pods-SnapchatKit_Example-SnapchatKit-prefix.pch"; sourceTree = "<group>"; };
+		58BA9F3FC2DC449A0D601CAFBB661733 /* NSValueTransformer+MTLInversionAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValueTransformer+MTLInversionAdditions.h"; path = "Mantle/NSValueTransformer+MTLInversionAdditions.h"; sourceTree = "<group>"; };
+		59F7C50BC794CD8AE4A522E621CBDEB2 /* Mantle.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Mantle.h; path = Mantle/Mantle.h; sourceTree = "<group>"; };
+		5ACEF1C64263788DDF0A871B5FD3415D /* ProtocolBuffers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ProtocolBuffers.h; sourceTree = "<group>"; };
+		5B78B5F838295F2C6CCA0316BE4A7C97 /* MTLJSONAdapter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MTLJSONAdapter.h; path = Mantle/MTLJSONAdapter.h; sourceTree = "<group>"; };
+		5BF03B1DF3F158AD62E2E36613DBCC66 /* Pods-SnapchatKit_Tests-Mantle.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; name = "Pods-SnapchatKit_Tests-Mantle.modulemap"; path = "../Pods-SnapchatKit_Tests-Mantle/Pods-SnapchatKit_Tests-Mantle.modulemap"; sourceTree = "<group>"; };
+		5D6DA22E10B78E607B571F2A55C30EF9 /* MTLJSONAdapter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MTLJSONAdapter.m; path = Mantle/MTLJSONAdapter.m; sourceTree = "<group>"; };
+		5DA60CBC900C38B9E72F99E56E639C3E /* SKUser.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKUser.h; sourceTree = "<group>"; };
+		5DD538EFE6D0B801F385F20D93048AED /* MutableExtensionRegistry.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MutableExtensionRegistry.h; sourceTree = "<group>"; };
+		5E8F6A76DF1D61C5C7225F9DDCD74CA3 /* WireFormat.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = WireFormat.h; sourceTree = "<group>"; };
+		5EB492FF04D6F8DCD3DC8589194EEE5B /* Pods-SnapchatKit_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SnapchatKit_Example-umbrella.h"; sourceTree = "<group>"; };
+		60201A8531061616003E37FB1E3AF624 /* Pods-SnapchatKit_Tests-Mantle.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SnapchatKit_Tests-Mantle.xcconfig"; path = "../Pods-SnapchatKit_Tests-Mantle/Pods-SnapchatKit_Tests-Mantle.xcconfig"; sourceTree = "<group>"; };
+		60324F862519F4C0542AB20FED27482B /* Pods-SnapchatKit-OSX-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-SnapchatKit-OSX-acknowledgements.markdown"; sourceTree = "<group>"; };
+		606FE432D85DF39B09C3DE7E82B31AD7 /* Attestation.pb.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = Attestation.pb.m; sourceTree = "<group>"; };
+		6192CF7FB23184D714C51581F7A1A1BE /* GeneratedMessageBuilder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = GeneratedMessageBuilder.h; sourceTree = "<group>"; };
+		6549D674C4BBFC4AE9F553D4ABED4F95 /* MTLReflection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MTLReflection.m; path = Mantle/MTLReflection.m; sourceTree = "<group>"; };
+		65BDC8FEB0C4DA73E242EB16763477BD /* Pods-SnapchatKit_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SnapchatKit_Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		65C6A40590103EE3AACC40219CF10B19 /* SKAddedFriend.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKAddedFriend.h; sourceTree = "<group>"; };
+		675A1892B3852A1B54788DAFCABDF585 /* Pods-SnapchatKit_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-SnapchatKit_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
+		67B7031A1CFE11F0B693963D8F04BA39 /* ForwardDeclarations.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ForwardDeclarations.h; sourceTree = "<group>"; };
+		6826B1CCA448E90716D8C1B6E74BC68B /* ConcreteExtensionField.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ConcreteExtensionField.h; sourceTree = "<group>"; };
+		68A1C5A3B897ADB8E2827950CE2912D7 /* Pods-SnapchatKit-OSX-SnapchatKit.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SnapchatKit-OSX-SnapchatKit.xcconfig"; sourceTree = "<group>"; };
+		6A5B71C481C0DEFF98AA08BF9328DB8C /* Pods-SnapchatKit_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-SnapchatKit_Example-dummy.m"; sourceTree = "<group>"; };
+		6CD8EAFBB8061AF2180363A65310EC7C /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../Pods-SnapchatKit_Tests-Mantle/Info.plist"; sourceTree = "<group>"; };
+		6F7FD588AA75CD3E573C15C8376669CF /* Pods-SnapchatKit_Example-Mantle.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; name = "Pods-SnapchatKit_Example-Mantle.modulemap"; path = "../Pods-SnapchatKit_Example-Mantle/Pods-SnapchatKit_Example-Mantle.modulemap"; sourceTree = "<group>"; };
+		709485E58BF2FF0A4C686203BE95E8EB /* MutableField.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MutableField.m; sourceTree = "<group>"; };
+		709FA66A2F3014164FA958C13FD036AE /* Pods-SnapchatKit_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SnapchatKit_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		70A50AB4E7409F7A938AA8915CE5522B /* TextFormat.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TextFormat.h; sourceTree = "<group>"; };
+		7141EAD9F0391CA0B89AA690FD467035 /* GeneratedMessage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = GeneratedMessage.m; sourceTree = "<group>"; };
+		71A8832A82F9F7AA9EB8BFCDD2C5BEB7 /* Pods-SnapchatKit_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SnapchatKit_Example.debug.xcconfig"; sourceTree = "<group>"; };
+		72F3609C47429493997503C14DD74194 /* Pods-SnapchatKit_Example-SnapchatKit.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SnapchatKit_Example-SnapchatKit.xcconfig"; path = "../Pods-SnapchatKit_Example-SnapchatKit/Pods-SnapchatKit_Example-SnapchatKit.xcconfig"; sourceTree = "<group>"; };
+		73839BEC40DA572D986E82BD377F57E7 /* Mantle.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mantle.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7451E9844399D33B0EF8F081DEE45BB9 /* ConcreteExtensionField.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ConcreteExtensionField.m; sourceTree = "<group>"; };
+		747032A30F0B0CFAE55E25EE38C28805 /* EXTRuntimeExtensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTRuntimeExtensions.h; path = Mantle/extobjc/EXTRuntimeExtensions.h; sourceTree = "<group>"; };
+		7548F1AD067B99B153C9CFDB0BC160DC /* SKFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKFilter.h; sourceTree = "<group>"; };
+		76AB741D014B1E9E1904F52DCD63BC2F /* Pods-SnapchatKit-OSX-SnapchatKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SnapchatKit-OSX-SnapchatKit-prefix.pch"; sourceTree = "<group>"; };
+		774C527EA09A09E0D8CD014D643D2268 /* SKStoryUpdater.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKStoryUpdater.h; sourceTree = "<group>"; };
+		783EA1ECC5FDE5F2CB4C6E1B8B5B9896 /* SKSharedStoryDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKSharedStoryDescription.m; sourceTree = "<group>"; };
+		79F59B49CE4DC99DF440AE4D85E72F6C /* crypt.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = crypt.h; sourceTree = "<group>"; };
+		7B86B77A0AE12A3715630EF1051CE196 /* SKClient+Snaps.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SKClient+Snaps.m"; sourceTree = "<group>"; };
+		7C240829368A1DC3E8EE782EEAF704A0 /* Mantle.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mantle.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7DF9455276C69ACF288FDCEEB316B212 /* NSDictionary+MTLJSONKeyPath.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSDictionary+MTLJSONKeyPath.m"; path = "Mantle/NSDictionary+MTLJSONKeyPath.m"; sourceTree = "<group>"; };
+		802057E388A43AE12453D12948E1951C /* SKSnap.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKSnap.m; sourceTree = "<group>"; };
+		80833A66B09D6D42B65135FA200C959A /* PBArray.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PBArray.m; sourceTree = "<group>"; };
+		81A6A60094231EA88DCE60750AA13AE1 /* SKLocation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKLocation.m; sourceTree = "<group>"; };
+		833D0F7844FB6F9844FF13EF09871134 /* SKClient+Friends.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SKClient+Friends.h"; sourceTree = "<group>"; };
+		84C3168646A0D3D84DBEAC87C1C0BDA6 /* SKFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKFilter.m; sourceTree = "<group>"; };
+		85DFBBC54289776922F83BCBCC6532F7 /* Pods_SnapchatKit_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SnapchatKit_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		864E8CC81A76CA838F6299352A05BC9D /* SSZipArchive.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SSZipArchive.h; sourceTree = "<group>"; };
+		884007D97EAC905D528F2D798D498CA3 /* mztools.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; path = mztools.c; sourceTree = "<group>"; };
+		8AD43FC9D3F58696526A320EAEDAF192 /* Pods-SnapchatKit-OSX-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-SnapchatKit-OSX-resources.sh"; sourceTree = "<group>"; };
+		8C57F7FD8AC70A5A980E7C0460CA2485 /* SnapchatKit-Constants.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SnapchatKit-Constants.m"; sourceTree = "<group>"; };
+		8D5F2EFE545E38C869A6A2D1EABEFE6F /* EXTScope.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXTScope.m; path = Mantle/extobjc/EXTScope.m; sourceTree = "<group>"; };
+		8DC6C59C7DEA6461C564B1DA58829542 /* Field.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = Field.m; sourceTree = "<group>"; };
+		90E3A46DADAE808ABCF8DA093A1F0A37 /* NSObject+MTLComparisonAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+MTLComparisonAdditions.h"; path = "Mantle/NSObject+MTLComparisonAdditions.h"; sourceTree = "<group>"; };
+		9172B364044C193573346831B47E3C32 /* SKThing.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKThing.m; sourceTree = "<group>"; };
+		9269F78B7355A85A30F6036EEAAC51C9 /* SKStory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKStory.m; sourceTree = "<group>"; };
+		93D7F125345B7EE254042449068E0D63 /* SKFoundFriend.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKFoundFriend.h; sourceTree = "<group>"; };
+		9412679689721ADFAAC7A895E02BA5AE /* SKRequest.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKRequest.m; sourceTree = "<group>"; };
+		94AE3C50908C86AECCE17C5B46647395 /* SKStoryNote.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKStoryNote.h; sourceTree = "<group>"; };
+		95104D76CE1DCD4A1284B6C141E0234E /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		965AD9BE4CDAD5BCF7FFD41667FE9D7C /* Pods-SnapchatKit_Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-SnapchatKit_Tests.modulemap"; sourceTree = "<group>"; };
+		978BF2612AD5B68A7A65BE361CCDD3DB /* AbstractMessageBuilder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = AbstractMessageBuilder.h; sourceTree = "<group>"; };
+		979970EC473F3B7EC64A997D0DAB7410 /* SKConversation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKConversation.m; sourceTree = "<group>"; };
+		97ABC90E3828E9031BC4F158D4F3EEE2 /* SKClient+Chat.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SKClient+Chat.h"; sourceTree = "<group>"; };
+		97EB582016DF519C59461B44ADCC6614 /* Pods-SnapchatKit_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-SnapchatKit_Example-frameworks.sh"; sourceTree = "<group>"; };
+		980768AD6081A72B8B07BB8294054202 /* Pods-SnapchatKit_Example-SnapchatKit-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-SnapchatKit_Example-SnapchatKit-umbrella.h"; path = "../Pods-SnapchatKit_Example-SnapchatKit/Pods-SnapchatKit_Example-SnapchatKit-umbrella.h"; sourceTree = "<group>"; };
+		98D1D45433BD6B5BD5B0FC1F93D93D5C /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../Pods-SnapchatKit_Tests-SnapchatKit/Info.plist"; sourceTree = "<group>"; };
+		9A69F98F1A3DEA5E52B393E4CA8AEAF9 /* PBArray.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PBArray.h; sourceTree = "<group>"; };
+		9AAF0F4CF61FEBE5F27F076EE43534B6 /* SKClient+Stories.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SKClient+Stories.m"; sourceTree = "<group>"; };
+		9C6AC9F19531D3677DC1E1AA6B8FB54C /* SKBlob.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKBlob.h; sourceTree = "<group>"; };
+		9D100EF1DDFEDE0151BADD810E249EF8 /* Pods_SnapchatKit_OSX.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SnapchatKit_OSX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9D74C791C2358D9D5C3D0605B6C1FE5A /* SKStoryCollection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKStoryCollection.m; sourceTree = "<group>"; };
+		A1742A790724662C0CC15EE77EC86B83 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		A1EF40FC91C9DF90C8F3375536DE9CAC /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A264A2B8EC9A2F9B22EB1FC09A2C9CDA /* Pods-SnapchatKit_Example-Mantle-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-SnapchatKit_Example-Mantle-prefix.pch"; path = "../Pods-SnapchatKit_Example-Mantle/Pods-SnapchatKit_Example-Mantle-prefix.pch"; sourceTree = "<group>"; };
+		A362FEDA412E6EA8B1971C25C70FDA47 /* Pods-SnapchatKit_Tests-Mantle-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-SnapchatKit_Tests-Mantle-dummy.m"; path = "../Pods-SnapchatKit_Tests-Mantle/Pods-SnapchatKit_Tests-Mantle-dummy.m"; sourceTree = "<group>"; };
+		A3A065B43F6F4A3AB98235E4C41E9E6A /* NSDictionary+MTLJSONKeyPath.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSDictionary+MTLJSONKeyPath.h"; path = "Mantle/NSDictionary+MTLJSONKeyPath.h"; sourceTree = "<group>"; };
+		A3B3600563469E165A512779D2952B19 /* NSError+MTLModelException.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSError+MTLModelException.m"; path = "Mantle/NSError+MTLModelException.m"; sourceTree = "<group>"; };
+		A47D5FB068E59938BD8CA832F286CBD7 /* Pods-SnapchatKit-OSX.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-SnapchatKit-OSX.modulemap"; sourceTree = "<group>"; };
+		A7E0035C4D44DD28CDC29DBEE88C9580 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValueTransformer+MTLPredefinedTransformerAdditions.m"; path = "Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m"; sourceTree = "<group>"; };
+		A80EB289DF56408DBC3088C043E15245 /* SKClient+Friends.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SKClient+Friends.m"; sourceTree = "<group>"; };
+		A975E788A258436FBB39267DBB6C7526 /* Pods-SnapchatKit_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SnapchatKit_Example-acknowledgements.plist"; sourceTree = "<group>"; };
+		AA054E5F64577F7C772D73102EF8F7C1 /* SKSession.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKSession.h; sourceTree = "<group>"; };
+		AA7B9832442745B728000CCF09AD59A2 /* CodedOutputStream.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = CodedOutputStream.m; sourceTree = "<group>"; };
+		ADC019666AAF7D7A212B5577793A36B8 /* Pods-SnapchatKit-OSX-Mantle-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-SnapchatKit-OSX-Mantle-dummy.m"; sourceTree = "<group>"; };
+		AEA4DB5D58231D27AC6CDE90D7240533 /* Field.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Field.h; sourceTree = "<group>"; };
+		AF2BABB30D0A63B528450704A8CC4831 /* SKNearbyUser.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKNearbyUser.h; sourceTree = "<group>"; };
+		B0B3A02E4506C7059D914FEF250427E1 /* MTLTransformerErrorHandling.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MTLTransformerErrorHandling.m; path = Mantle/MTLTransformerErrorHandling.m; sourceTree = "<group>"; };
+		B178E7B7DF86E0DBEE7A51DB140F29A3 /* Pods-SnapchatKit-OSX.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SnapchatKit-OSX.debug.xcconfig"; sourceTree = "<group>"; };
+		B29E8F6A2790D070998F9CF5CF7EE4D1 /* NSArray+MTLManipulationAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSArray+MTLManipulationAdditions.m"; path = "Mantle/NSArray+MTLManipulationAdditions.m"; sourceTree = "<group>"; };
+		B313D16EBCED2CE282F1548F5502B190 /* Pods-SnapchatKit_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SnapchatKit_Example.release.xcconfig"; sourceTree = "<group>"; };
+		B3547AAE494746F0CF2277659F9390E4 /* GeneratedMessage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = GeneratedMessage.h; sourceTree = "<group>"; };
+		B4B133121782FD34737B816B9476DBF9 /* SKStory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKStory.h; sourceTree = "<group>"; };
+		B7A69314EE3DFAF88133C81C375BC4B5 /* Pods-SnapchatKit_Tests-SnapchatKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-SnapchatKit_Tests-SnapchatKit-prefix.pch"; path = "../Pods-SnapchatKit_Tests-SnapchatKit/Pods-SnapchatKit_Tests-SnapchatKit-prefix.pch"; sourceTree = "<group>"; };
+		B7ABCBE17F86FB9BEECA8062A041C9AC /* Message.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Message.h; sourceTree = "<group>"; };
+		B9231F31123010FDAB359C1EE6306140 /* EXTScope.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTScope.h; path = Mantle/extobjc/EXTScope.h; sourceTree = "<group>"; };
+		B93970AA91389B580BA81FA9119ABEB4 /* Pods-SnapchatKit_Example-Mantle.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SnapchatKit_Example-Mantle.xcconfig"; path = "../Pods-SnapchatKit_Example-Mantle/Pods-SnapchatKit_Example-Mantle.xcconfig"; sourceTree = "<group>"; };
+		B99D5FA99A6C1A06B1CC07FF55B44986 /* ioapi.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ioapi.h; sourceTree = "<group>"; };
+		B9D44DAC0AEC22A9F263443521D59009 /* Pods-SnapchatKit_Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-SnapchatKit_Tests-frameworks.sh"; sourceTree = "<group>"; };
+		BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		BA7F4D5E4C8595A3D1AE0EB307C2CB8E /* Pods-SnapchatKit_Example-Mantle-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-SnapchatKit_Example-Mantle-umbrella.h"; path = "../Pods-SnapchatKit_Example-Mantle/Pods-SnapchatKit_Example-Mantle-umbrella.h"; sourceTree = "<group>"; };
+		BBFDD148F657EF9DEBA791AE4CA9E411 /* SnapchatKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SnapchatKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C1655D290963794DB4DD8A91377BAC2E /* Pods-SnapchatKit-OSX-SnapchatKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-SnapchatKit-OSX-SnapchatKit-dummy.m"; sourceTree = "<group>"; };
+		C166F11F874CC66F155035BD723C973A /* CodedOutputStream.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = CodedOutputStream.h; sourceTree = "<group>"; };
+		C1F491F9A8489CC37E4E1795E1924489 /* AbstractMessageBuilder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = AbstractMessageBuilder.m; sourceTree = "<group>"; };
+		C24C62067E53B9DD2EB633790E6EECEA /* SKUserStory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKUserStory.h; sourceTree = "<group>"; };
+		C2CC45708F858B3A21FA14F2C3AE0C49 /* SKSimpleUser.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKSimpleUser.m; sourceTree = "<group>"; };
+		C889F248D1DED2AFD880A16BC306586F /* SKStoryOptions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKStoryOptions.m; sourceTree = "<group>"; };
+		C90F6DCB8E6D5E5AD3B2C839EDF984C8 /* Attestation.pb.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Attestation.pb.h; sourceTree = "<group>"; };
+		C92D1BDBA53A4FEE02AF9F6BF1B2EE66 /* Pods-SnapchatKit-OSX-Mantle.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-SnapchatKit-OSX-Mantle.modulemap"; sourceTree = "<group>"; };
+		C93DEA42EF984A92E5FFF4F5EA4C4576 /* MTLTransformerErrorHandling.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MTLTransformerErrorHandling.h; path = Mantle/MTLTransformerErrorHandling.h; sourceTree = "<group>"; };
+		C994D8C3A0E2BD2F6A50788977A698B4 /* EXTRuntimeExtensions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXTRuntimeExtensions.m; path = Mantle/extobjc/EXTRuntimeExtensions.m; sourceTree = "<group>"; };
+		CBA1FDCD70D710D40E0FEE2504BB4C9B /* Pods-SnapchatKit_Example-Mantle-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-SnapchatKit_Example-Mantle-dummy.m"; path = "../Pods-SnapchatKit_Example-Mantle/Pods-SnapchatKit_Example-Mantle-dummy.m"; sourceTree = "<group>"; };
+		CDEAC9BF0BF4585523A58300F58B3CDD /* Pods-SnapchatKit-OSX.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SnapchatKit-OSX.release.xcconfig"; sourceTree = "<group>"; };
+		CDF8D63AD3F269AECF961EB562B4584D /* ObjectivecDescriptor.pb.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ObjectivecDescriptor.pb.h; sourceTree = "<group>"; };
+		CE4ABDF04FF8494E1C5D6E053D288B2A /* SnapchatKit-Constants.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SnapchatKit-Constants.h"; sourceTree = "<group>"; };
+		CEB772F1CD2E64A93211D413F991E158 /* SKClient+Stories.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SKClient+Stories.h"; sourceTree = "<group>"; };
+		D13B01407D9005CF9C5677552DCDC6A1 /* ExtendableMessage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ExtendableMessage.m; sourceTree = "<group>"; };
+		D3BD5BF0576E52C406DDEC99C0EBF5B3 /* Pods-SnapchatKit-OSX-SnapchatKit-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SnapchatKit-OSX-SnapchatKit-umbrella.h"; sourceTree = "<group>"; };
+		D5738FF9A898F9686A3AE9C8BF64405A /* Pods-SnapchatKit_Tests-SnapchatKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-SnapchatKit_Tests-SnapchatKit-dummy.m"; path = "../Pods-SnapchatKit_Tests-SnapchatKit/Pods-SnapchatKit_Tests-SnapchatKit-dummy.m"; sourceTree = "<group>"; };
+		D64A94D4DFB38E5653DD76D20218BE09 /* CodedInputStream.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = CodedInputStream.m; sourceTree = "<group>"; };
+		D6CD685B05060FD7B7E01EF0D9851D1E /* Pods-SnapchatKit_Example-SnapchatKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-SnapchatKit_Example-SnapchatKit-dummy.m"; path = "../Pods-SnapchatKit_Example-SnapchatKit/Pods-SnapchatKit_Example-SnapchatKit-dummy.m"; sourceTree = "<group>"; };
+		D7120C8C40EF2A6454683D2023AA4521 /* TextFormat.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TextFormat.m; sourceTree = "<group>"; };
+		D7AD70060269B4629B407FE76BD9B976 /* RingBuffer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RingBuffer.m; sourceTree = "<group>"; };
+		D7CA4D711558564E92AE1DD7E0974424 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D7E76263E298B94207690529D04D43D2 /* Pods-SnapchatKit_Tests-Mantle-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-SnapchatKit_Tests-Mantle-prefix.pch"; path = "../Pods-SnapchatKit_Tests-Mantle/Pods-SnapchatKit_Tests-Mantle-prefix.pch"; sourceTree = "<group>"; };
+		D8762D8E7B4291A96A1D301857929925 /* Pods_SnapchatKit_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SnapchatKit_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D917EDD76808D4D21F22960E1DE309C8 /* MTLModel+NSCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "MTLModel+NSCoding.h"; path = "Mantle/MTLModel+NSCoding.h"; sourceTree = "<group>"; };
+		DCD2256F10F763F211E4C0CA353ABC10 /* NSDictionary+MTLMappingAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSDictionary+MTLMappingAdditions.h"; path = "Mantle/NSDictionary+MTLMappingAdditions.h"; sourceTree = "<group>"; };
+		DD4D2DD38DC19BF04525CD76056DF23B /* SKSnapResponse.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKSnapResponse.m; sourceTree = "<group>"; };
+		DDF462ACA7D6BE321BE504088CFC8EC9 /* SKClient+Device.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SKClient+Device.m"; sourceTree = "<group>"; };
+		DE3FD306D6487F5A6E0F63B0BA4493A1 /* SKClient.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKClient.h; sourceTree = "<group>"; };
+		DEDC7956355FEA315D3DEEC5062CF304 /* Pods-SnapchatKit_Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SnapchatKit_Tests-acknowledgements.plist"; sourceTree = "<group>"; };
+		DF085137EB0F35B5B37260EABF2BC4FF /* NSDictionary+MTLManipulationAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSDictionary+MTLManipulationAdditions.h"; path = "Mantle/NSDictionary+MTLManipulationAdditions.h"; sourceTree = "<group>"; };
+		E059AC38BADB0D1B36F1843E1BE50C2F /* Utilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = Utilities.m; sourceTree = "<group>"; };
+		E37D0CF02FAE213B04ECCF59E1F09308 /* Pods-SnapchatKit-OSX-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SnapchatKit-OSX-acknowledgements.plist"; sourceTree = "<group>"; };
+		E3D463D60137F8318D301057A1ECFDB5 /* MessageBuilder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MessageBuilder.h; sourceTree = "<group>"; };
+		E54E26EDFAA3F10A36830DE50A7A5B14 /* SKSimpleUser.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKSimpleUser.h; sourceTree = "<group>"; };
+		E6316AA0C110D87D7C0CEE4F992074FC /* SKSharedStoryDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKSharedStoryDescription.h; sourceTree = "<group>"; };
+		E6543108894562824171DF82C827C732 /* SKNewConversation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKNewConversation.m; sourceTree = "<group>"; };
+		E6B8AC488192EFFE38ABFA7054D5FAE7 /* MutableField.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MutableField.h; sourceTree = "<group>"; };
+		E723F5E599FCD85ABFD4F911E3DDDE5F /* SKRequest.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKRequest.h; sourceTree = "<group>"; };
+		E7264B33B0A0713CE212280490FD1800 /* SKStoryNote.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKStoryNote.m; sourceTree = "<group>"; };
+		E76B54A5B681A52C9BF1A48F75B3DE3F /* unzip.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; path = unzip.c; sourceTree = "<group>"; };
+		E7FF2C7F1C9F03E9F9FFEEEB71828E5D /* UnknownFieldSet.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = UnknownFieldSet.m; sourceTree = "<group>"; };
+		E9AF192BD8DD526AEB6FD5A02EEB2A56 /* SKThing.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKThing.h; sourceTree = "<group>"; };
+		EBBA31D126C126E59033F575AD6BEF9B /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../Pods-SnapchatKit_Example-Mantle/Info.plist"; sourceTree = "<group>"; };
+		EBF31098D1B73D4027EF54C1B7EC55E7 /* SKUserStory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKUserStory.m; sourceTree = "<group>"; };
+		EC153DEC3715CFBB867734E4DCF5C9D6 /* SKBlob.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKBlob.m; sourceTree = "<group>"; };
+		ED040AD1A09159B67F92E0C54034D46E /* Pods-SnapchatKit_Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SnapchatKit_Tests-umbrella.h"; sourceTree = "<group>"; };
+		F1D1A5B737A29E03602B5C8212455D59 /* EXTKeyPathCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTKeyPathCoding.h; path = Mantle/extobjc/EXTKeyPathCoding.h; sourceTree = "<group>"; };
+		F20808D5847A1BE5576F1E97363F4126 /* NSArray+SnapchatKit.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSArray+SnapchatKit.m"; sourceTree = "<group>"; };
+		F33789AB1CD889C76EE417221D59C3D9 /* SKCashTransaction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKCashTransaction.m; sourceTree = "<group>"; };
+		F4B5E1A7AAE7E607AC9E54D4FA333BAB /* UnknownFieldSetBuilder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = UnknownFieldSetBuilder.h; sourceTree = "<group>"; };
+		FA6432BA5246C1551C4A472E13F3505C /* Pods-SnapchatKit_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-SnapchatKit_Example.modulemap"; sourceTree = "<group>"; };
+		FB0E1FAC0060ECAB08CEE29646BFE32A /* NSValueTransformer+MTLPredefinedTransformerAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValueTransformer+MTLPredefinedTransformerAdditions.h"; path = "Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.h"; sourceTree = "<group>"; };
+		FB2D208BA9563060C0278C6D8F71C479 /* zip.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = zip.h; sourceTree = "<group>"; };
+		FEBB2E828CE404D19FE3169CB4CE45B6 /* SKConversation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SKConversation.h; sourceTree = "<group>"; };
+		FEC4C213ED5CC2EB2BD905D67424B9CE /* Pods-SnapchatKit_Tests-Mantle-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-SnapchatKit_Tests-Mantle-umbrella.h"; path = "../Pods-SnapchatKit_Tests-Mantle/Pods-SnapchatKit_Tests-Mantle-umbrella.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		2ED87702250B297AD11540B2 /* Frameworks */ = {
+		27A2C544AEEC64460D64252FC3008D5C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				19E14AD871D0C43BAB0E101F /* Foundation.framework in Frameworks */,
+				55ECDA2A000835ADC3D1CFFC8B1AA105 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		393CCFAF77618A8DDD8EE00A /* Frameworks */ = {
+		35D5FF0BA533231D687B47A54FD97916 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F77E198A0817B517E733DE6C /* Foundation.framework in Frameworks */,
+				2B0F64923471BA3F63DC781C394ADEC0 /* Cocoa.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		3BBAB5DCA822959497177775 /* Frameworks */ = {
+		9EDFCF6799EB2B83ED09175E674A8E50 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F3471EDD1EC90CC4D1411676 /* Cocoa.framework in Frameworks */,
+				01F6E48CB9D03467B4E5E15A86E9E696 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		488F3B09FCC98D5F27D08DF4 /* Frameworks */ = {
+		B827C6DD8793A275E99D59559CED9DA1 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6ECC478906622A6C4BBC72FB /* Cocoa.framework in Frameworks */,
+				AE70AC3F7CFEC76E3E616333BF1F854A /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		5B5C1FA09C4DB7175CC572C9 /* Frameworks */ = {
+		B94198371F2F6D5FB4E765C0726204BA /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C083EF2CA7FE862AB249BBB3 /* Foundation.framework in Frameworks */,
+				34E59F617948E6EEEEC2B2D129564333 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		77C202995891D3CA0F5E92A3 /* Frameworks */ = {
+		C1C160069678D16739769E6F774CD6E2 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				566406164ADB5D858AC2220C /* Cocoa.framework in Frameworks */,
-				294C993A8A0D629589C4DFE6 /* Foundation.framework in Frameworks */,
+				00F6A1A5886C968EAEF709F025C629BD /* Foundation.framework in Frameworks */,
+				B1B806F787A2841D03ADB6E235DB5756 /* Mantle.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		7A1BD9880A5895DE3581BA17 /* Frameworks */ = {
+		D7D13D1E99FC565A58D508032461765F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				62C5851BD4E387FD75A22EF7 /* Foundation.framework in Frameworks */,
+				EEFD1F92F6CCEEA2C2C5803EAC2FF640 /* Foundation.framework in Frameworks */,
+				282B53B2BA402322977754FB8714551A /* Mantle.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FE3E06C3E1887EEFDF9294F2 /* Frameworks */ = {
+		E72438EE943DC85CB384D007AE7AC244 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				73B08A70FD2A9CDD08114B9C /* Foundation.framework in Frameworks */,
+				31A006C7D74D36E484C66524FB9B94E2 /* Cocoa.framework in Frameworks */,
+				55DEE1A5E27B40C5DA252D92BFB01ACC /* Mantle.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FE7A3C950EDF8854D90116BB /* Frameworks */ = {
+		E72F781885FCF473502480C447E73CD8 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				37A160E0567E6599C2185A43 /* Foundation.framework in Frameworks */,
+				09475913E1E8F8A5C967C95D101B5748 /* Cocoa.framework in Frameworks */,
+				B504BF8CA9CAFBB209026B4A7E190A33 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		033179AC85A88184955D378C /* Targets Support Files */ = {
+		02936640AEAAD12A47F2E5DC3ACB8B48 /* minizip */ = {
 			isa = PBXGroup;
 			children = (
-				E99AF044D73A53F9980ACDAF /* Pods-SnapchatKit-OSX */,
-				19933517A2671403F1FE6522 /* Pods-SnapchatKit_Example */,
-				C5CDF4CFE73127E8D18FD1F5 /* Pods-SnapchatKit_Tests */,
-			);
-			name = "Targets Support Files";
-			sourceTree = "<group>";
-		};
-		0368548F566E5D33A4335F55 /* extobjc */ = {
-			isa = PBXGroup;
-			children = (
-				A9FBC3803D641A8AF3A1A033 /* EXTKeyPathCoding.h */,
-				515761136CC4D2DA31CBDCCE /* EXTRuntimeExtensions.h */,
-				8C23DFF2F44056D492331988 /* EXTRuntimeExtensions.m */,
-				1D4A7091C6DE37C14EBE847D /* EXTScope.h */,
-				74DF1D6CA9D178F9CEE62E29 /* EXTScope.m */,
-				0AA75375F2F52C8E60ABBCCB /* metamacros.h */,
-			);
-			name = extobjc;
-			sourceTree = "<group>";
-		};
-		0BA29BF3C2262C189F6434C8 /* OS X */ = {
-			isa = PBXGroup;
-			children = (
-				825834A937BE3CAE02AB2EB9 /* Cocoa.framework */,
-				6CCF63F998DDD570BF396F60 /* Foundation.framework */,
-			);
-			name = "OS X";
-			sourceTree = "<group>";
-		};
-		102D76258D0211B27FC9CB0E /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				DE838DF4E4D69C85F9B1A008 /* Mantle */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
-		19933517A2671403F1FE6522 /* Pods-SnapchatKit_Example */ = {
-			isa = PBXGroup;
-			children = (
-				B248168DD03CA01E639F3B0F /* Info.plist */,
-				E51DD16CB1A38D500A0D81DF /* Pods-SnapchatKit_Example.modulemap */,
-				016FE40D9852B7D7C16202BB /* Pods-SnapchatKit_Example-acknowledgements.markdown */,
-				415D7284CB388E44D7F0FD42 /* Pods-SnapchatKit_Example-acknowledgements.plist */,
-				4F9C3899FAAC648953D8E96C /* Pods-SnapchatKit_Example-dummy.m */,
-				3EA20DEDFF58DCEC2DCACEEF /* Pods-SnapchatKit_Example-environment.h */,
-				C89FFC35CCC557BCAB64BE65 /* Pods-SnapchatKit_Example-frameworks.sh */,
-				832988A136ED728E71274116 /* Pods-SnapchatKit_Example-resources.sh */,
-				31356904078AF381495527D2 /* Pods-SnapchatKit_Example-umbrella.h */,
-				FAA670771CDCBC81331CC379 /* Pods-SnapchatKit_Example.debug.xcconfig */,
-				90D6B47A535307DE73D6422E /* Pods-SnapchatKit_Example.release.xcconfig */,
-			);
-			name = "Pods-SnapchatKit_Example";
-			path = "Target Support Files/Pods-SnapchatKit_Example";
-			sourceTree = "<group>";
-		};
-		273C8BE74F77BBF9C720E338 /* Model */ = {
-			isa = PBXGroup;
-			children = (
-				A766840A3FA15875DD115B84 /* SKAddedFriend.h */,
-				8CB417E7FA3A2177453C0458 /* SKAddedFriend.m */,
-				4A08CC8E2AC99F2D225D628E /* SKBlob.h */,
-				C72DBD7A6DA7655074E62D29 /* SKBlob.m */,
-				EBAC7CF928D68AD3EE37FB4D /* SKCashTransaction.h */,
-				21D7027B0107A87B98B269DD /* SKCashTransaction.m */,
-				57804134FAC62DB389FA867E /* SKConversation.h */,
-				701146DB20AFF386866AA783 /* SKConversation.m */,
-				8CC372A04E32E3B5A10B6683 /* SKFilter.h */,
-				B3034C9C4729EFDDAF24276C /* SKFilter.m */,
-				607499C80038757E311F8CA1 /* SKFoundFriend.h */,
-				B71A42ED9C9A282E7A4B4542 /* SKFoundFriend.m */,
-				1CE06043D4DC81317EE540DE /* SKLocation.h */,
-				2BD6662AFDE6D73BB17E57D0 /* SKLocation.m */,
-				2B7029FB4531206FAF1E971E /* SKMessage.h */,
-				EB8FB810CD3E9AF9303846D2 /* SKMessage.m */,
-				7C7595A2095D32ABE35F10FE /* SKNearbyUser.h */,
-				DC77D677392F90E40D0F2B2F /* SKNearbyUser.m */,
-				5FFFD75623FB9218D73DE323 /* SKNewConversation.h */,
-				150E0D42F8ADD64688F5FF77 /* SKNewConversation.m */,
-				87DC6A533A3CB69CFE3FC6D8 /* SKRequest.h */,
-				FB3E8A3A6BAD4DE5DB3BD0B3 /* SKRequest.m */,
-				8ADC4AAB6A6ABCE48BCC5F84 /* SKSession.h */,
-				E258F52BF2199045E866A6F0 /* SKSession.m */,
-				8FD3C16495412F844A298EA3 /* SKSharedStoryDescription.h */,
-				F1D451149D1CCB912DFC59DA /* SKSharedStoryDescription.m */,
-				BFA49567896C833E44B3C4A1 /* SKSimpleUser.h */,
-				022825FCF2BAF08416579518 /* SKSimpleUser.m */,
-				4FF03725A1FBD01F3B54D410 /* SKSnap.h */,
-				7E8F65183882F17A3EE5BA5D /* SKSnap.m */,
-				B97745F20B56DFE00D4434D7 /* SKSnapOptions.h */,
-				00F7E64375D906AADEEBE012 /* SKSnapOptions.m */,
-				F128C2CF8C3AF119EF791658 /* SKSnapResponse.h */,
-				123AA38787CE03C6CCCD59EF /* SKSnapResponse.m */,
-				76CC3491B3E0E22C56D21730 /* SKStory.h */,
-				346F22DD245A0A72527AE1C8 /* SKStory.m */,
-				B475512FAECA1EDC22AF0197 /* SKStoryCollection.h */,
-				3F6C4F7854C482C05E42ED2B /* SKStoryCollection.m */,
-				5CC5CD60538DCDD4998B4E9D /* SKStoryNote.h */,
-				445678C61FB42AB9BD4D4D49 /* SKStoryNote.m */,
-				1198650DD0951EF6D7936CB7 /* SKStoryOptions.h */,
-				F9884910EFC1C632C163D4E9 /* SKStoryOptions.m */,
-				AD9CE5C7E8B71B7A717BF7CF /* SKStoryUpdater.h */,
-				F2DB5DC9CB68ABDBF1C8F8AE /* SKStoryUpdater.m */,
-				FF2964E8E281C6629782BFF8 /* SKThing.h */,
-				480232BB439E70191B69829A /* SKThing.m */,
-				5ED60ED9A8DEB4AF13B67CC8 /* SKUser.h */,
-				9B86948413F2BA125B8C7D03 /* SKUser.m */,
-				FD60E62E28DCF876A104F0A7 /* SKUserStory.h */,
-				90F41EB5F4D4C93EFA06977B /* SKUserStory.m */,
-			);
-			path = Model;
-			sourceTree = "<group>";
-		};
-		2F76B22B7EE9DA56FD1879C5 /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				B5911E28A3492693B6A367C7 /* Classes */,
-				DC56735ABBD7387968FBCAF6 /* Dependencies */,
-			);
-			path = Pod;
-			sourceTree = "<group>";
-		};
-		3A8B2F93FB88ABB91EBA0817 /* Networking */ = {
-			isa = PBXGroup;
-			children = (
-				BC234E8391D1425381C05523 /* Attestation.pb.h */,
-				E4C61B7D956E59989273650A /* Attestation.pb.m */,
-				AD3C9AC8DBADBCAB8DA86DA8 /* SKClient.h */,
-				7E47188605DEAD31B32CA84A /* SKClient.m */,
-				468545A3D0F59F8EB5EC8623 /* SKClient+Account.h */,
-				36ECBA089FD3718EDC1195C0 /* SKClient+Account.m */,
-				F552284B16EA501247330C10 /* SKClient+Chat.h */,
-				31201F9C36DCB8072A773375 /* SKClient+Chat.m */,
-				F1DE6FC4BDB289A1735EC820 /* SKClient+Device.h */,
-				B82E05A3E46B11BD9BF8921D /* SKClient+Device.m */,
-				FCA6532B428B695F70814807 /* SKClient+Discover.h */,
-				DCDA93F546D12297EA015005 /* SKClient+Discover.m */,
-				CD7CF6D3EDE14721A9FA183B /* SKClient+Friends.h */,
-				A1ACEF81DAC35F3667E86099 /* SKClient+Friends.m */,
-				E4DD12BC1374B1D0F8A542E6 /* SKClient+Snaps.h */,
-				C59B176424A659FA44EB301D /* SKClient+Snaps.m */,
-				0352130AD3816023F8068ECA /* SKClient+Stories.h */,
-				17D0AA7AA0EA6CC242B330F9 /* SKClient+Stories.m */,
-			);
-			path = Networking;
-			sourceTree = "<group>";
-		};
-		3CF9CF72A5547F84B406879A /* Development Pods */ = {
-			isa = PBXGroup;
-			children = (
-				A55E8967BD4240113C2B8AFC /* SnapchatKit */,
-			);
-			name = "Development Pods";
-			sourceTree = "<group>";
-		};
-		4A9582C0D8D5A2E89AB5B30E /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				1873516313DE12A18B441976 /* Mantle.framework */,
-				53233F46F0A7FEE3BAB2F5F0 /* Mantle.framework */,
-				B9E73BE37CE97F84CA411252 /* Mantle.framework */,
-				59D88C1F1755D563CB421C63 /* Pods_SnapchatKit_Example.framework */,
-				F54BFB630D034BFBDD1AD679 /* Pods_SnapchatKit_OSX.framework */,
-				5BCC3D97332ACAEB112939B8 /* Pods_SnapchatKit_Tests.framework */,
-				0B18B08E9AA35CE5DC2A6970 /* SnapchatKit.framework */,
-				88B84931C4029CE138B1A35A /* SnapchatKit.framework */,
-				92E7239EFF6E75EA9F6F3561 /* SnapchatKit.framework */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		6A82CF794C47FF6919B45EE0 /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				01A3D282D76F2492158972A9 /* Foundation.framework */,
-			);
-			name = iOS;
-			sourceTree = "<group>";
-		};
-		6F1B0FEA084B2F7350A4E076 /* Categories */ = {
-			isa = PBXGroup;
-			children = (
-				5458179AFBA3B4551E76D06C /* NSArray+SnapchatKit.h */,
-				4693BF7FBC62DA24F8CB6153 /* NSArray+SnapchatKit.m */,
-				9BE3B4334F276CA5FE417047 /* NSData+SnapchatKit.h */,
-				DA7D052FF7B5D4F9FAB6264F /* NSData+SnapchatKit.m */,
-				8E7CA746CADA1BDA8DFD79E9 /* NSDictionary+SnapchatKit.h */,
-				1EDA4E519FE1136F8E6159C2 /* NSDictionary+SnapchatKit.m */,
-				7B208DD3ECC3E9C53BF230B7 /* NSString+SnapchatKit.h */,
-				74DA603BC9A41DF99F80FF9C /* NSString+SnapchatKit.m */,
-			);
-			path = Categories;
-			sourceTree = "<group>";
-		};
-		8B9AAD070D3401BF97BBBC6D /* protobuf */ = {
-			isa = PBXGroup;
-			children = (
-				4F32C4F587D89334A3BCBE23 /* AbstractMessage.h */,
-				C55205D98ACA2596E3A93000 /* AbstractMessage.m */,
-				40971082BAA72F1F1EDAF695 /* AbstractMessageBuilder.h */,
-				35EF0345D98539E68C6DCCF0 /* AbstractMessageBuilder.m */,
-				7183BB0F3292AEE43022E891 /* Bootstrap.h */,
-				29CFD017511A61FDEEFEF7FB /* CodedInputStream.h */,
-				5D2A3B038ECCCA6DF6D3B46B /* CodedInputStream.m */,
-				0F89D17AA09083FFEC8C72CF /* CodedOutputStream.h */,
-				90D507AAE40D2CEED0D36687 /* CodedOutputStream.m */,
-				53E643E4011CFF791437DE5C /* ConcreteExtensionField.h */,
-				7604B3135534C28027647CD5 /* ConcreteExtensionField.m */,
-				B5F8AE9D9CC92F9D2639DE69 /* Descriptor.pb.h */,
-				53358FC1AF684CCB6202172F /* Descriptor.pb.m */,
-				81D3C8E6CF0E4B9EC98608DF /* ExtendableMessage.h */,
-				6070FF02167CEB9FC7458D39 /* ExtendableMessage.m */,
-				8F10C5B94F9F3FF19B6B285D /* ExtendableMessageBuilder.h */,
-				676BE47EFE38F1493CD05107 /* ExtendableMessageBuilder.m */,
-				57779D995D4EED4517C14162 /* ExtensionField.h */,
-				679719A8EC9FC6E3B23D6151 /* ExtensionRegistry.h */,
-				1628AB0CEF6EECD372AA222B /* ExtensionRegistry.m */,
-				F347842C5587B36F931554EC /* Field.h */,
-				549084617E4D5DCBD4ED4B0E /* Field.m */,
-				5F96C5D607778F1ABE0AA9A9 /* ForwardDeclarations.h */,
-				F6310B7A8D4CCC215C36FC42 /* GeneratedMessage.h */,
-				6532EFC9D4874C91D352A810 /* GeneratedMessage.m */,
-				116CA5F3E415255E8D2A4C6B /* GeneratedMessageBuilder.h */,
-				A22019B34FF3D28330B16DF5 /* GeneratedMessageBuilder.m */,
-				90BEF1EF981624D8235EE9E6 /* Message.h */,
-				0746351ADCB0B21FE32B2E85 /* MessageBuilder.h */,
-				5D85386BB83B94415BF95032 /* MutableExtensionRegistry.h */,
-				6DC7CD3FB2E0D2C3AF55E726 /* MutableExtensionRegistry.m */,
-				B359AC7608C8680235607B64 /* MutableField.h */,
-				FEAB71425CD10455E6D75F28 /* MutableField.m */,
-				F9218CE3AF46DF110AC1FC93 /* ObjectivecDescriptor.pb.h */,
-				2B450E93CAE222E73572A5BA /* ObjectivecDescriptor.pb.m */,
-				D1A0970111F805282AEC6CAD /* PBArray.h */,
-				D14F237EC025DFF27B83C274 /* PBArray.m */,
-				60CD411A1CA63391B2D224AB /* ProtocolBuffers.h */,
-				AA149B4D211D5124D4002334 /* RingBuffer.h */,
-				7D12E82F0CEA77B8F7DE1F9B /* RingBuffer.m */,
-				3BE6AF84EBA6D92BCE5C7636 /* TextFormat.h */,
-				502600138FD1162EC5F0E835 /* TextFormat.m */,
-				7A2AAA454116F315A4C5A440 /* UnknownFieldSet.h */,
-				1DD52DE4A9AAD6E3A69EB894 /* UnknownFieldSet.m */,
-				AAEE9103C8BA8123534B7278 /* UnknownFieldSetBuilder.h */,
-				71577F1A49CF27CC9FA94074 /* UnknownFieldSetBuilder.m */,
-				B758A255FCB12557BF687DBF /* Utilities.h */,
-				11064E9E55CF944B7E747575 /* Utilities.m */,
-				91FD8FDCB1EF8E5342243FB7 /* WireFormat.h */,
-				E6DCF7D3DF29FF7F743F3642 /* WireFormat.m */,
-			);
-			path = protobuf;
-			sourceTree = "<group>";
-		};
-		9462076815C7C24A7BC15EF0 = {
-			isa = PBXGroup;
-			children = (
-				BE23F92F0AF5FAC9B46B1080 /* Podfile */,
-				3CF9CF72A5547F84B406879A /* Development Pods */,
-				E6B0B86BD0B55E38D2D736C5 /* Frameworks */,
-				102D76258D0211B27FC9CB0E /* Pods */,
-				4A9582C0D8D5A2E89AB5B30E /* Products */,
-				033179AC85A88184955D378C /* Targets Support Files */,
-			);
-			sourceTree = "<group>";
-		};
-		9F357CEAF7D6DA241A6EFF09 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				CE41466A7EA286DF1DA66939 /* Info.plist */,
-				20C9C55D2ED86B58CAF02D6C /* Info.plist */,
-				A41479F50FBF748BB5D19D50 /* Info.plist */,
-				B9DAF269D11078378EFFAF9F /* Pods-SnapchatKit-OSX-Mantle.modulemap */,
-				48071AFDE030FA44AF31654C /* Pods-SnapchatKit-OSX-Mantle.xcconfig */,
-				A00A37246F318C66CDCFC569 /* Pods-SnapchatKit-OSX-Mantle-Private.xcconfig */,
-				8D31FC75657D73CC0298E1EF /* Pods-SnapchatKit-OSX-Mantle-dummy.m */,
-				19686F6CA6E05777DCB4F394 /* Pods-SnapchatKit-OSX-Mantle-prefix.pch */,
-				C91FA387C6BC12DFCEC16B08 /* Pods-SnapchatKit-OSX-Mantle-umbrella.h */,
-				77332B89D8076A70739B6766 /* Pods-SnapchatKit_Example-Mantle.modulemap */,
-				44845973A3A65096EB9FCC26 /* Pods-SnapchatKit_Example-Mantle.xcconfig */,
-				DF748A340BF9306E32B97ED3 /* Pods-SnapchatKit_Example-Mantle-Private.xcconfig */,
-				A7C23396CBC972AE283C6179 /* Pods-SnapchatKit_Example-Mantle-dummy.m */,
-				4D47212A4D9D5CE2BCB35089 /* Pods-SnapchatKit_Example-Mantle-prefix.pch */,
-				9A37A0F5E40E5D3D0B42D25A /* Pods-SnapchatKit_Example-Mantle-umbrella.h */,
-				815680717120B8611BBFE344 /* Pods-SnapchatKit_Tests-Mantle.modulemap */,
-				5F95A3237B10A013B18BFE81 /* Pods-SnapchatKit_Tests-Mantle.xcconfig */,
-				C5DE13676C268EA621449922 /* Pods-SnapchatKit_Tests-Mantle-Private.xcconfig */,
-				DA1D849137C33690C52103DA /* Pods-SnapchatKit_Tests-Mantle-dummy.m */,
-				3897135FC4BE5D51EF3A68BF /* Pods-SnapchatKit_Tests-Mantle-prefix.pch */,
-				138BBC48171ED63193A16737 /* Pods-SnapchatKit_Tests-Mantle-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Pods-SnapchatKit-OSX-Mantle";
-			sourceTree = "<group>";
-		};
-		A55E8967BD4240113C2B8AFC /* SnapchatKit */ = {
-			isa = PBXGroup;
-			children = (
-				2F76B22B7EE9DA56FD1879C5 /* Pod */,
-				BFFA62EB898FCA135FCD3F7A /* Support Files */,
-			);
-			name = SnapchatKit;
-			path = ../..;
-			sourceTree = "<group>";
-		};
-		B02D1ABA39DBA70DEF92FCC7 /* minizip */ = {
-			isa = PBXGroup;
-			children = (
-				34BDFDCAB53D1C3DF3D8B643 /* crypt.h */,
-				0A8FA92E556068A6CE1CCE16 /* ioapi.c */,
-				9A0021AF19BB03BE8068C892 /* ioapi.h */,
-				7137BB5CBC818BC0E912BAE8 /* mztools.c */,
-				6D9B66EB6E20F1C7D4AD8AA0 /* mztools.h */,
-				367E68898317851726B59744 /* unzip.c */,
-				366DC11AD62752B2C3E9393B /* unzip.h */,
-				EB9C7549B766712AC0F5F9F7 /* zip.c */,
-				36535381D153E491915E5B96 /* zip.h */,
+				79F59B49CE4DC99DF440AE4D85E72F6C /* crypt.h */,
+				4EBD65303E77D9EF88B73826511C216D /* ioapi.c */,
+				B99D5FA99A6C1A06B1CC07FF55B44986 /* ioapi.h */,
+				884007D97EAC905D528F2D798D498CA3 /* mztools.c */,
+				1685FA7977E1A72A8CA039CF99A88D23 /* mztools.h */,
+				E76B54A5B681A52C9BF1A48F75B3DE3F /* unzip.c */,
+				4FE550472E08ABD8D5B741D1077F61BA /* unzip.h */,
+				4F0F9FF93E2C703E32F8511026F85347 /* zip.c */,
+				FB2D208BA9563060C0278C6D8F71C479 /* zip.h */,
 			);
 			path = minizip;
 			sourceTree = "<group>";
 		};
-		B5911E28A3492693B6A367C7 /* Classes */ = {
+		1CD3F438ED428A312090DB3F3C8DE735 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
-				D3CB8B66AC28E9296B200E45 /* SnapchatKit.h */,
-				5A4E677C0A6B08357EDE38B3 /* SnapchatKit-Constants.h */,
-				60FCE66689CCF5D0D0C98357 /* SnapchatKit-Constants.m */,
-				6F1B0FEA084B2F7350A4E076 /* Categories */,
-				273C8BE74F77BBF9C720E338 /* Model */,
-				3A8B2F93FB88ABB91EBA0817 /* Networking */,
+				46EF97B3320D5567B3CD996D681E6DB9 /* Foundation.framework */,
 			);
-			path = Classes;
+			name = iOS;
 			sourceTree = "<group>";
 		};
-		BFFA62EB898FCA135FCD3F7A /* Support Files */ = {
+		25E357B009931E2CB3584CA4E5C25B12 /* Pods-SnapchatKit_Tests */ = {
 			isa = PBXGroup;
 			children = (
-				758F4DBFC84E4E8F2CDD9609 /* Info.plist */,
-				E4C3F559B4946C7AB8AFA8A4 /* Info.plist */,
-				F6E2FD20F292E5625A4FE3BE /* Info.plist */,
-				AA6CFFAEAE05991AB9B2A783 /* Pods-SnapchatKit-OSX-SnapchatKit.modulemap */,
-				79123DA71B89B29494D4B96D /* Pods-SnapchatKit-OSX-SnapchatKit.xcconfig */,
-				7E9DDD2E3FB426249A82B662 /* Pods-SnapchatKit-OSX-SnapchatKit-Private.xcconfig */,
-				6D2B9EB3ED194082F399A655 /* Pods-SnapchatKit-OSX-SnapchatKit-dummy.m */,
-				F026B71E625916EE223E04FF /* Pods-SnapchatKit-OSX-SnapchatKit-prefix.pch */,
-				E0BE5272169F0ABBBAE1A7C3 /* Pods-SnapchatKit-OSX-SnapchatKit-umbrella.h */,
-				A00BAA82C52FA3361AD62FC3 /* Pods-SnapchatKit_Example-SnapchatKit.modulemap */,
-				C0AA124AA5FC698AF6045124 /* Pods-SnapchatKit_Example-SnapchatKit.xcconfig */,
-				DFEB6906EBD2B7C0F34E76B4 /* Pods-SnapchatKit_Example-SnapchatKit-Private.xcconfig */,
-				ABEFC3F1ABD4E8AFE75B8DF3 /* Pods-SnapchatKit_Example-SnapchatKit-dummy.m */,
-				E214FDD4BCEA0508B7346283 /* Pods-SnapchatKit_Example-SnapchatKit-prefix.pch */,
-				7429D3F53C745B01ABB0BD0A /* Pods-SnapchatKit_Example-SnapchatKit-umbrella.h */,
-				2F5EAB4555DEC9D840E6827D /* Pods-SnapchatKit_Tests-SnapchatKit.modulemap */,
-				8D812C332409657DC581A5D4 /* Pods-SnapchatKit_Tests-SnapchatKit.xcconfig */,
-				B2CC18BCB4D507891F83A273 /* Pods-SnapchatKit_Tests-SnapchatKit-Private.xcconfig */,
-				E9AEA239EC2FAC0FBDB45EE7 /* Pods-SnapchatKit_Tests-SnapchatKit-dummy.m */,
-				5D76E52DF8BD7923ED927F40 /* Pods-SnapchatKit_Tests-SnapchatKit-prefix.pch */,
-				80B92F86F6383AF6373514DC /* Pods-SnapchatKit_Tests-SnapchatKit-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "Example/Pods/Target Support Files/Pods-SnapchatKit-OSX-SnapchatKit";
-			sourceTree = "<group>";
-		};
-		C5CDF4CFE73127E8D18FD1F5 /* Pods-SnapchatKit_Tests */ = {
-			isa = PBXGroup;
-			children = (
-				49123558EC733737D4B7828B /* Info.plist */,
-				3F736D4FA1DF5519A4A7088E /* Pods-SnapchatKit_Tests.modulemap */,
-				DC1C419D734F0A8C9DA47458 /* Pods-SnapchatKit_Tests-acknowledgements.markdown */,
-				A6E7159BC244D52AEB941180 /* Pods-SnapchatKit_Tests-acknowledgements.plist */,
-				3373DEC2ACD88C7B0D7E398D /* Pods-SnapchatKit_Tests-dummy.m */,
-				0BB3F424212EAD00F4624235 /* Pods-SnapchatKit_Tests-environment.h */,
-				A404DFA42617BDF6EDEE50D3 /* Pods-SnapchatKit_Tests-frameworks.sh */,
-				DEFFD560FDB1107DBA31BD0C /* Pods-SnapchatKit_Tests-resources.sh */,
-				C3CACC2CC8A6328EED00102F /* Pods-SnapchatKit_Tests-umbrella.h */,
-				215676CE55DE6C39627F6595 /* Pods-SnapchatKit_Tests.debug.xcconfig */,
-				2D2E53E10F5777B5687B8B84 /* Pods-SnapchatKit_Tests.release.xcconfig */,
+				A1EF40FC91C9DF90C8F3375536DE9CAC /* Info.plist */,
+				965AD9BE4CDAD5BCF7FFD41667FE9D7C /* Pods-SnapchatKit_Tests.modulemap */,
+				675A1892B3852A1B54788DAFCABDF585 /* Pods-SnapchatKit_Tests-acknowledgements.markdown */,
+				DEDC7956355FEA315D3DEEC5062CF304 /* Pods-SnapchatKit_Tests-acknowledgements.plist */,
+				0FAFA003B01F71668975B806F52809BB /* Pods-SnapchatKit_Tests-dummy.m */,
+				B9D44DAC0AEC22A9F263443521D59009 /* Pods-SnapchatKit_Tests-frameworks.sh */,
+				1CC8F0208F6B00877587B5E36CC3FCB9 /* Pods-SnapchatKit_Tests-resources.sh */,
+				ED040AD1A09159B67F92E0C54034D46E /* Pods-SnapchatKit_Tests-umbrella.h */,
+				65BDC8FEB0C4DA73E242EB16763477BD /* Pods-SnapchatKit_Tests.debug.xcconfig */,
+				709FA66A2F3014164FA958C13FD036AE /* Pods-SnapchatKit_Tests.release.xcconfig */,
 			);
 			name = "Pods-SnapchatKit_Tests";
 			path = "Target Support Files/Pods-SnapchatKit_Tests";
 			sourceTree = "<group>";
 		};
-		DC56735ABBD7387968FBCAF6 /* Dependencies */ = {
+		2A5E7F1C3F0AF66057E38E06ED3D40BF /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				5846DBD972BB2E4E8516487A /* SSZipArchive.h */,
-				9580C868D4BD628B16033847 /* SSZipArchive.m */,
-				B02D1ABA39DBA70DEF92FCC7 /* minizip */,
-				8B9AAD070D3401BF97BBBC6D /* protobuf */,
-			);
-			path = Dependencies;
-			sourceTree = "<group>";
-		};
-		DE838DF4E4D69C85F9B1A008 /* Mantle */ = {
-			isa = PBXGroup;
-			children = (
-				CD40B957499A960C0F251F7A /* MTLJSONAdapter.h */,
-				F275805645C8FED83BC58CE7 /* MTLJSONAdapter.m */,
-				FF09072CAEC86883CBD1C5B7 /* MTLModel.h */,
-				E2FB4A4D3FF57F7B9A0C482C /* MTLModel.m */,
-				C49BF5D2D648742FCBBC6433 /* MTLModel+NSCoding.h */,
-				1B58BC08B10D15123B320AFD /* MTLModel+NSCoding.m */,
-				9EBA09F0C92556545D654BDD /* MTLReflection.h */,
-				B0A48052AEB65F7B647DB473 /* MTLReflection.m */,
-				6E2EF527D485AA3518965377 /* MTLTransformerErrorHandling.h */,
-				5F3BDE1CAA9A717200841609 /* MTLTransformerErrorHandling.m */,
-				8EE2DC94841F1D57870388D7 /* MTLValueTransformer.h */,
-				7403F5AB3E4BE3F53F76912D /* MTLValueTransformer.m */,
-				E143F32D6FBEF9E2E0AD119E /* Mantle.h */,
-				4762A159FAA8CE845790577D /* NSArray+MTLManipulationAdditions.h */,
-				7718349A691AC354D56DB602 /* NSArray+MTLManipulationAdditions.m */,
-				864BFCBBD456ACC6691691E9 /* NSDictionary+MTLJSONKeyPath.h */,
-				E1DC65C5D930DE74DF698A83 /* NSDictionary+MTLJSONKeyPath.m */,
-				D62E5A585E176727B114DBF8 /* NSDictionary+MTLManipulationAdditions.h */,
-				4A09000891FE155F04E84237 /* NSDictionary+MTLManipulationAdditions.m */,
-				B74CCA0F13F010EF6C5F3108 /* NSDictionary+MTLMappingAdditions.h */,
-				B4399388D431562C74758070 /* NSDictionary+MTLMappingAdditions.m */,
-				A91683F22FB4EF562527CCF8 /* NSError+MTLModelException.h */,
-				EDDC5E23649AF7A1E0BB82E8 /* NSError+MTLModelException.m */,
-				AACC20FB1D0DE81D97FC7F46 /* NSObject+MTLComparisonAdditions.h */,
-				E3F90C74F6B4513DB6B80D92 /* NSObject+MTLComparisonAdditions.m */,
-				79892EA1B4AA29856078EE35 /* NSValueTransformer+MTLInversionAdditions.h */,
-				2C7985E1F9182ABE6BA9D3DE /* NSValueTransformer+MTLInversionAdditions.m */,
-				E85AA3FDA1B47E649DCA1DD1 /* NSValueTransformer+MTLPredefinedTransformerAdditions.h */,
-				C90C099E43248D72169A5B0B /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */,
-				9F357CEAF7D6DA241A6EFF09 /* Support Files */,
-				0368548F566E5D33A4335F55 /* extobjc */,
-			);
-			path = Mantle;
-			sourceTree = "<group>";
-		};
-		E6B0B86BD0B55E38D2D736C5 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				0BA29BF3C2262C189F6434C8 /* OS X */,
-				6A82CF794C47FF6919B45EE0 /* iOS */,
+				73839BEC40DA572D986E82BD377F57E7 /* Mantle.framework */,
+				1CD3F438ED428A312090DB3F3C8DE735 /* iOS */,
+				DAE15CFAED1DE0D4950541467FF7D5EE /* OS X */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		E99AF044D73A53F9980ACDAF /* Pods-SnapchatKit-OSX */ = {
+		4B1CC94A88B569D36BA4824B58A6A7F8 /* Pods-SnapchatKit_Example */ = {
 			isa = PBXGroup;
 			children = (
-				449CC84B46793A16723EFAF3 /* Info.plist */,
-				B72804C93C3C7282FF48DBB1 /* Pods-SnapchatKit-OSX.modulemap */,
-				86036A1F4EC5319555943E4A /* Pods-SnapchatKit-OSX-acknowledgements.markdown */,
-				B18A7FA8139D76C64101D79E /* Pods-SnapchatKit-OSX-acknowledgements.plist */,
-				73C1CB4E2FE3CF7FA2BAC175 /* Pods-SnapchatKit-OSX-dummy.m */,
-				1D05C23668A6E8B4DEF4111C /* Pods-SnapchatKit-OSX-environment.h */,
-				DBA9AE1A1E5EF9F254B40F05 /* Pods-SnapchatKit-OSX-frameworks.sh */,
-				605083736A08598B67B8C393 /* Pods-SnapchatKit-OSX-resources.sh */,
-				503F98FEAAC39B02E3C4B2F1 /* Pods-SnapchatKit-OSX-umbrella.h */,
-				B651D104642825FF7BC7098D /* Pods-SnapchatKit-OSX.debug.xcconfig */,
-				FE9A32571C6172EF5F9B70FD /* Pods-SnapchatKit-OSX.release.xcconfig */,
+				3563C30BD97F4D46B5D201946CBD33E3 /* Info.plist */,
+				FA6432BA5246C1551C4A472E13F3505C /* Pods-SnapchatKit_Example.modulemap */,
+				3C0564DF17975EEE8CA66A75B382953E /* Pods-SnapchatKit_Example-acknowledgements.markdown */,
+				A975E788A258436FBB39267DBB6C7526 /* Pods-SnapchatKit_Example-acknowledgements.plist */,
+				6A5B71C481C0DEFF98AA08BF9328DB8C /* Pods-SnapchatKit_Example-dummy.m */,
+				97EB582016DF519C59461B44ADCC6614 /* Pods-SnapchatKit_Example-frameworks.sh */,
+				40340A31E91934BEB2CDCC541B6E29B8 /* Pods-SnapchatKit_Example-resources.sh */,
+				5EB492FF04D6F8DCD3DC8589194EEE5B /* Pods-SnapchatKit_Example-umbrella.h */,
+				71A8832A82F9F7AA9EB8BFCDD2C5BEB7 /* Pods-SnapchatKit_Example.debug.xcconfig */,
+				B313D16EBCED2CE282F1548F5502B190 /* Pods-SnapchatKit_Example.release.xcconfig */,
+			);
+			name = "Pods-SnapchatKit_Example";
+			path = "Target Support Files/Pods-SnapchatKit_Example";
+			sourceTree = "<group>";
+		};
+		6A0ABFB90CC0F51F4308645664BA3FE8 /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				97C21A1119B2716BA731E6668A6C2B15 /* Classes */,
+				A41AF9842D35E2C645E802B8AC57B054 /* Dependencies */,
+			);
+			path = Pod;
+			sourceTree = "<group>";
+		};
+		7196FB889A458E9519E4610F6AF098E8 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				EBBA31D126C126E59033F575AD6BEF9B /* Info.plist */,
+				D7CA4D711558564E92AE1DD7E0974424 /* Info.plist */,
+				6CD8EAFBB8061AF2180363A65310EC7C /* Info.plist */,
+				C92D1BDBA53A4FEE02AF9F6BF1B2EE66 /* Pods-SnapchatKit-OSX-Mantle.modulemap */,
+				33BC1AF5B43B9D9D4E7129B4BC704208 /* Pods-SnapchatKit-OSX-Mantle.xcconfig */,
+				ADC019666AAF7D7A212B5577793A36B8 /* Pods-SnapchatKit-OSX-Mantle-dummy.m */,
+				213011217E41F65FB2C0DC3B9627855E /* Pods-SnapchatKit-OSX-Mantle-prefix.pch */,
+				400621EB0B2F9F65897A439566594B63 /* Pods-SnapchatKit-OSX-Mantle-umbrella.h */,
+				6F7FD588AA75CD3E573C15C8376669CF /* Pods-SnapchatKit_Example-Mantle.modulemap */,
+				B93970AA91389B580BA81FA9119ABEB4 /* Pods-SnapchatKit_Example-Mantle.xcconfig */,
+				CBA1FDCD70D710D40E0FEE2504BB4C9B /* Pods-SnapchatKit_Example-Mantle-dummy.m */,
+				A264A2B8EC9A2F9B22EB1FC09A2C9CDA /* Pods-SnapchatKit_Example-Mantle-prefix.pch */,
+				BA7F4D5E4C8595A3D1AE0EB307C2CB8E /* Pods-SnapchatKit_Example-Mantle-umbrella.h */,
+				5BF03B1DF3F158AD62E2E36613DBCC66 /* Pods-SnapchatKit_Tests-Mantle.modulemap */,
+				60201A8531061616003E37FB1E3AF624 /* Pods-SnapchatKit_Tests-Mantle.xcconfig */,
+				A362FEDA412E6EA8B1971C25C70FDA47 /* Pods-SnapchatKit_Tests-Mantle-dummy.m */,
+				D7E76263E298B94207690529D04D43D2 /* Pods-SnapchatKit_Tests-Mantle-prefix.pch */,
+				FEC4C213ED5CC2EB2BD905D67424B9CE /* Pods-SnapchatKit_Tests-Mantle-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Pods-SnapchatKit-OSX-Mantle";
+			sourceTree = "<group>";
+		};
+		7DB346D0F39D3F0E887471402A8071AB = {
+			isa = PBXGroup;
+			children = (
+				BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */,
+				FF466D3B3F9D1124E4C5FD18BACF7E5C /* Development Pods */,
+				2A5E7F1C3F0AF66057E38E06ED3D40BF /* Frameworks */,
+				D4E67CE9469A57EDA0BF9A4FBDD6CF21 /* Pods */,
+				EB3F31200506B4EC0BAB38AC0E45DC53 /* Products */,
+				F9D32B222D2EB45C67B89BC4030E6B7F /* Targets Support Files */,
+			);
+			sourceTree = "<group>";
+		};
+		7EEDB97D38672F83D2C1631F3806ACC1 /* extobjc */ = {
+			isa = PBXGroup;
+			children = (
+				F1D1A5B737A29E03602B5C8212455D59 /* EXTKeyPathCoding.h */,
+				747032A30F0B0CFAE55E25EE38C28805 /* EXTRuntimeExtensions.h */,
+				C994D8C3A0E2BD2F6A50788977A698B4 /* EXTRuntimeExtensions.m */,
+				B9231F31123010FDAB359C1EE6306140 /* EXTScope.h */,
+				8D5F2EFE545E38C869A6A2D1EABEFE6F /* EXTScope.m */,
+				184E597AA48D3822ECF8AEB2135DD087 /* metamacros.h */,
+			);
+			name = extobjc;
+			sourceTree = "<group>";
+		};
+		82BCE0F32FB0C27A74EC0651C9B56FD7 /* Categories */ = {
+			isa = PBXGroup;
+			children = (
+				444ABAE227428925EDF5D132A91868E4 /* NSArray+SnapchatKit.h */,
+				F20808D5847A1BE5576F1E97363F4126 /* NSArray+SnapchatKit.m */,
+				1508934AF2E2EE2B2C6287E8D0FD729E /* NSData+SnapchatKit.h */,
+				3AC6595E4B0F1881632644CBC0879775 /* NSData+SnapchatKit.m */,
+				523519361513D98C2F08E815B11DEF1B /* NSDictionary+SnapchatKit.h */,
+				3337FCDB5568A74D24743FFB6337720A /* NSDictionary+SnapchatKit.m */,
+				01D3D233D27189A14C4D48B64946BEDC /* NSString+SnapchatKit.h */,
+				54460D90C5A5A625598F1A72569A13B5 /* NSString+SnapchatKit.m */,
+			);
+			path = Categories;
+			sourceTree = "<group>";
+		};
+		87FB6E2EC9635D29E13A645EC4CEE38A /* protobuf */ = {
+			isa = PBXGroup;
+			children = (
+				07EAD9F6F9FA6CF821F00410E5793C55 /* AbstractMessage.h */,
+				1E3B442CA4C99021E31A08D4467D4203 /* AbstractMessage.m */,
+				978BF2612AD5B68A7A65BE361CCDD3DB /* AbstractMessageBuilder.h */,
+				C1F491F9A8489CC37E4E1795E1924489 /* AbstractMessageBuilder.m */,
+				30F3816561C0672DD603262F36C61EB4 /* Bootstrap.h */,
+				04365EC94A261DF5AA309962BFE4E7AA /* CodedInputStream.h */,
+				D64A94D4DFB38E5653DD76D20218BE09 /* CodedInputStream.m */,
+				C166F11F874CC66F155035BD723C973A /* CodedOutputStream.h */,
+				AA7B9832442745B728000CCF09AD59A2 /* CodedOutputStream.m */,
+				6826B1CCA448E90716D8C1B6E74BC68B /* ConcreteExtensionField.h */,
+				7451E9844399D33B0EF8F081DEE45BB9 /* ConcreteExtensionField.m */,
+				0A58A6FF946BC36ACBE07A96585CF06D /* Descriptor.pb.h */,
+				55BA9EA15DD7130BEC47C5B99EC9384A /* Descriptor.pb.m */,
+				00655651C6BA81463B1F1AC19D408EFB /* ExtendableMessage.h */,
+				D13B01407D9005CF9C5677552DCDC6A1 /* ExtendableMessage.m */,
+				151083D0F45656947CF1BAD22F86B9EE /* ExtendableMessageBuilder.h */,
+				4D2C9634F9F032DDCBE25B9910E30A5A /* ExtendableMessageBuilder.m */,
+				01E0A94D80868EC6EA02AE1C229EAC5D /* ExtensionField.h */,
+				06B966634B688674E5961D625443E7E4 /* ExtensionRegistry.h */,
+				37186F3BDEF4361A87EE611FE929CFB9 /* ExtensionRegistry.m */,
+				AEA4DB5D58231D27AC6CDE90D7240533 /* Field.h */,
+				8DC6C59C7DEA6461C564B1DA58829542 /* Field.m */,
+				67B7031A1CFE11F0B693963D8F04BA39 /* ForwardDeclarations.h */,
+				B3547AAE494746F0CF2277659F9390E4 /* GeneratedMessage.h */,
+				7141EAD9F0391CA0B89AA690FD467035 /* GeneratedMessage.m */,
+				6192CF7FB23184D714C51581F7A1A1BE /* GeneratedMessageBuilder.h */,
+				463D5934C525845DDF6D4108DF174801 /* GeneratedMessageBuilder.m */,
+				B7ABCBE17F86FB9BEECA8062A041C9AC /* Message.h */,
+				E3D463D60137F8318D301057A1ECFDB5 /* MessageBuilder.h */,
+				5DD538EFE6D0B801F385F20D93048AED /* MutableExtensionRegistry.h */,
+				39300C3939F3E500421A1E0654225D36 /* MutableExtensionRegistry.m */,
+				E6B8AC488192EFFE38ABFA7054D5FAE7 /* MutableField.h */,
+				709485E58BF2FF0A4C686203BE95E8EB /* MutableField.m */,
+				CDF8D63AD3F269AECF961EB562B4584D /* ObjectivecDescriptor.pb.h */,
+				4149CC5EE78E849EAF5DEEFEE5B0AA66 /* ObjectivecDescriptor.pb.m */,
+				9A69F98F1A3DEA5E52B393E4CA8AEAF9 /* PBArray.h */,
+				80833A66B09D6D42B65135FA200C959A /* PBArray.m */,
+				5ACEF1C64263788DDF0A871B5FD3415D /* ProtocolBuffers.h */,
+				31F648378E994908BE3DEFFBD2CEB0CB /* RingBuffer.h */,
+				D7AD70060269B4629B407FE76BD9B976 /* RingBuffer.m */,
+				70A50AB4E7409F7A938AA8915CE5522B /* TextFormat.h */,
+				D7120C8C40EF2A6454683D2023AA4521 /* TextFormat.m */,
+				2FDCF9C141D2B76551E065804EB72AF7 /* UnknownFieldSet.h */,
+				E7FF2C7F1C9F03E9F9FFEEEB71828E5D /* UnknownFieldSet.m */,
+				F4B5E1A7AAE7E607AC9E54D4FA333BAB /* UnknownFieldSetBuilder.h */,
+				15787D58A018F7C163848E0EDEFFF2AB /* UnknownFieldSetBuilder.m */,
+				2FADA08C22B41CD08228C4250C6B1A70 /* Utilities.h */,
+				E059AC38BADB0D1B36F1843E1BE50C2F /* Utilities.m */,
+				5E8F6A76DF1D61C5C7225F9DDCD74CA3 /* WireFormat.h */,
+				4687F307C6DF4771125FACD4FEF41B6F /* WireFormat.m */,
+			);
+			path = protobuf;
+			sourceTree = "<group>";
+		};
+		8E9DCF51AF082C910D7DB288BECDBE04 /* SnapchatKit */ = {
+			isa = PBXGroup;
+			children = (
+				6A0ABFB90CC0F51F4308645664BA3FE8 /* Pod */,
+				9132AC209E8064C5F7DC145C4D6EDD98 /* Support Files */,
+			);
+			name = SnapchatKit;
+			path = ../..;
+			sourceTree = "<group>";
+		};
+		9132AC209E8064C5F7DC145C4D6EDD98 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				380466204986D63E3FD15C708124D907 /* Info.plist */,
+				95104D76CE1DCD4A1284B6C141E0234E /* Info.plist */,
+				98D1D45433BD6B5BD5B0FC1F93D93D5C /* Info.plist */,
+				456E2A07499A9C18F57AB9FC2613962F /* Pods-SnapchatKit-OSX-SnapchatKit.modulemap */,
+				68A1C5A3B897ADB8E2827950CE2912D7 /* Pods-SnapchatKit-OSX-SnapchatKit.xcconfig */,
+				C1655D290963794DB4DD8A91377BAC2E /* Pods-SnapchatKit-OSX-SnapchatKit-dummy.m */,
+				76AB741D014B1E9E1904F52DCD63BC2F /* Pods-SnapchatKit-OSX-SnapchatKit-prefix.pch */,
+				D3BD5BF0576E52C406DDEC99C0EBF5B3 /* Pods-SnapchatKit-OSX-SnapchatKit-umbrella.h */,
+				2A2690F1D5C31BAE7B8B476DDDD6C6B9 /* Pods-SnapchatKit_Example-SnapchatKit.modulemap */,
+				72F3609C47429493997503C14DD74194 /* Pods-SnapchatKit_Example-SnapchatKit.xcconfig */,
+				D6CD685B05060FD7B7E01EF0D9851D1E /* Pods-SnapchatKit_Example-SnapchatKit-dummy.m */,
+				55E237D731C5ED759D5ED0585F50D2F3 /* Pods-SnapchatKit_Example-SnapchatKit-prefix.pch */,
+				980768AD6081A72B8B07BB8294054202 /* Pods-SnapchatKit_Example-SnapchatKit-umbrella.h */,
+				116F42487EDA4A9494C64821E46329F4 /* Pods-SnapchatKit_Tests-SnapchatKit.modulemap */,
+				3B5C08557F4B29304AA56AEC7D400D9F /* Pods-SnapchatKit_Tests-SnapchatKit.xcconfig */,
+				D5738FF9A898F9686A3AE9C8BF64405A /* Pods-SnapchatKit_Tests-SnapchatKit-dummy.m */,
+				B7A69314EE3DFAF88133C81C375BC4B5 /* Pods-SnapchatKit_Tests-SnapchatKit-prefix.pch */,
+				558B475B8EB352B7580B26A69BF74125 /* Pods-SnapchatKit_Tests-SnapchatKit-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "Example/Pods/Target Support Files/Pods-SnapchatKit-OSX-SnapchatKit";
+			sourceTree = "<group>";
+		};
+		97C21A1119B2716BA731E6668A6C2B15 /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				2E8E9BC41A16B11C168D078CD7578264 /* SnapchatKit.h */,
+				CE4ABDF04FF8494E1C5D6E053D288B2A /* SnapchatKit-Constants.h */,
+				8C57F7FD8AC70A5A980E7C0460CA2485 /* SnapchatKit-Constants.m */,
+				82BCE0F32FB0C27A74EC0651C9B56FD7 /* Categories */,
+				D6CDFCE7174669158A91D579C58A2E4D /* Model */,
+				EAB3CFF5545E65A5516988F15AAF55ED /* Networking */,
+			);
+			path = Classes;
+			sourceTree = "<group>";
+		};
+		A41AF9842D35E2C645E802B8AC57B054 /* Dependencies */ = {
+			isa = PBXGroup;
+			children = (
+				864E8CC81A76CA838F6299352A05BC9D /* SSZipArchive.h */,
+				0595D336EA25C014342530119C843CA6 /* SSZipArchive.m */,
+				02936640AEAAD12A47F2E5DC3ACB8B48 /* minizip */,
+				87FB6E2EC9635D29E13A645EC4CEE38A /* protobuf */,
+			);
+			path = Dependencies;
+			sourceTree = "<group>";
+		};
+		D4E67CE9469A57EDA0BF9A4FBDD6CF21 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				F403355360BF744BC09ED8683A01EAFA /* Mantle */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		D6CDFCE7174669158A91D579C58A2E4D /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				65C6A40590103EE3AACC40219CF10B19 /* SKAddedFriend.h */,
+				168FBDE79E6B224781B59DDED990CC1D /* SKAddedFriend.m */,
+				9C6AC9F19531D3677DC1E1AA6B8FB54C /* SKBlob.h */,
+				EC153DEC3715CFBB867734E4DCF5C9D6 /* SKBlob.m */,
+				0A0F9C65CF3106FAC238CDC512FF51E2 /* SKCashTransaction.h */,
+				F33789AB1CD889C76EE417221D59C3D9 /* SKCashTransaction.m */,
+				FEBB2E828CE404D19FE3169CB4CE45B6 /* SKConversation.h */,
+				979970EC473F3B7EC64A997D0DAB7410 /* SKConversation.m */,
+				7548F1AD067B99B153C9CFDB0BC160DC /* SKFilter.h */,
+				84C3168646A0D3D84DBEAC87C1C0BDA6 /* SKFilter.m */,
+				93D7F125345B7EE254042449068E0D63 /* SKFoundFriend.h */,
+				31E2210149C81E3944A0BE1276CAC3A1 /* SKFoundFriend.m */,
+				25B50FC7D431013529A4EDF7982F6C0A /* SKLocation.h */,
+				81A6A60094231EA88DCE60750AA13AE1 /* SKLocation.m */,
+				0CA59E7E475EC4C780AB17196EE1F175 /* SKMessage.h */,
+				5532B761F50A991D01D8E66810F650B5 /* SKMessage.m */,
+				AF2BABB30D0A63B528450704A8CC4831 /* SKNearbyUser.h */,
+				4825B54E2CDC5AA561EF544825F2A14F /* SKNearbyUser.m */,
+				2A537E793DA2330169541319E2AD1A2A /* SKNewConversation.h */,
+				E6543108894562824171DF82C827C732 /* SKNewConversation.m */,
+				E723F5E599FCD85ABFD4F911E3DDDE5F /* SKRequest.h */,
+				9412679689721ADFAAC7A895E02BA5AE /* SKRequest.m */,
+				AA054E5F64577F7C772D73102EF8F7C1 /* SKSession.h */,
+				0460FB606CE25E0ACED9CBF453B53217 /* SKSession.m */,
+				E6316AA0C110D87D7C0CEE4F992074FC /* SKSharedStoryDescription.h */,
+				783EA1ECC5FDE5F2CB4C6E1B8B5B9896 /* SKSharedStoryDescription.m */,
+				E54E26EDFAA3F10A36830DE50A7A5B14 /* SKSimpleUser.h */,
+				C2CC45708F858B3A21FA14F2C3AE0C49 /* SKSimpleUser.m */,
+				48D10AA8FB91C836871332883EEE8C79 /* SKSnap.h */,
+				802057E388A43AE12453D12948E1951C /* SKSnap.m */,
+				102BD1F037C4B0705E82FACAADBC648A /* SKSnapOptions.h */,
+				3F8EFE9CDCA52EC0CCBD1DF32DA061F4 /* SKSnapOptions.m */,
+				2FBEB3B3FA6CC7990C60F15777A0090E /* SKSnapResponse.h */,
+				DD4D2DD38DC19BF04525CD76056DF23B /* SKSnapResponse.m */,
+				B4B133121782FD34737B816B9476DBF9 /* SKStory.h */,
+				9269F78B7355A85A30F6036EEAAC51C9 /* SKStory.m */,
+				45A8B9B178D3D50255BED3D0FCB98A78 /* SKStoryCollection.h */,
+				9D74C791C2358D9D5C3D0605B6C1FE5A /* SKStoryCollection.m */,
+				94AE3C50908C86AECCE17C5B46647395 /* SKStoryNote.h */,
+				E7264B33B0A0713CE212280490FD1800 /* SKStoryNote.m */,
+				2349A4CD323EDCB9F3445312B2F9489A /* SKStoryOptions.h */,
+				C889F248D1DED2AFD880A16BC306586F /* SKStoryOptions.m */,
+				774C527EA09A09E0D8CD014D643D2268 /* SKStoryUpdater.h */,
+				34D90DB5D3A0F6C9F52829680C3A220D /* SKStoryUpdater.m */,
+				E9AF192BD8DD526AEB6FD5A02EEB2A56 /* SKThing.h */,
+				9172B364044C193573346831B47E3C32 /* SKThing.m */,
+				5DA60CBC900C38B9E72F99E56E639C3E /* SKUser.h */,
+				5515DC27DAB5541F75B0AA3425061AAE /* SKUser.m */,
+				C24C62067E53B9DD2EB633790E6EECEA /* SKUserStory.h */,
+				EBF31098D1B73D4027EF54C1B7EC55E7 /* SKUserStory.m */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		DAE15CFAED1DE0D4950541467FF7D5EE /* OS X */ = {
+			isa = PBXGroup;
+			children = (
+				0D7CCAAC157EB2E8A7F7A2290A48C89A /* Cocoa.framework */,
+				A1742A790724662C0CC15EE77EC86B83 /* Foundation.framework */,
+			);
+			name = "OS X";
+			sourceTree = "<group>";
+		};
+		EAB3CFF5545E65A5516988F15AAF55ED /* Networking */ = {
+			isa = PBXGroup;
+			children = (
+				C90F6DCB8E6D5E5AD3B2C839EDF984C8 /* Attestation.pb.h */,
+				606FE432D85DF39B09C3DE7E82B31AD7 /* Attestation.pb.m */,
+				DE3FD306D6487F5A6E0F63B0BA4493A1 /* SKClient.h */,
+				0E0A9E84EC29594B57D6036A4B137EB0 /* SKClient.m */,
+				4CBC1007B50FB6D8D8CCC49C9AA3A908 /* SKClient+Account.h */,
+				20F34E602ECE0E9952C0C9CC8D2E971A /* SKClient+Account.m */,
+				97ABC90E3828E9031BC4F158D4F3EEE2 /* SKClient+Chat.h */,
+				23C622E56337996E2A8713254F5BD246 /* SKClient+Chat.m */,
+				2E8C22914F0D53BA79853BCCAE38D6A0 /* SKClient+Device.h */,
+				DDF462ACA7D6BE321BE504088CFC8EC9 /* SKClient+Device.m */,
+				4B6CEADD2D0C33311B5DF1F367E954A5 /* SKClient+Discover.h */,
+				3483A1EC7B5CF9FAD309261F6519CDF3 /* SKClient+Discover.m */,
+				833D0F7844FB6F9844FF13EF09871134 /* SKClient+Friends.h */,
+				A80EB289DF56408DBC3088C043E15245 /* SKClient+Friends.m */,
+				1FEA67B46E224685AD9C805D1A27E5D9 /* SKClient+Snaps.h */,
+				7B86B77A0AE12A3715630EF1051CE196 /* SKClient+Snaps.m */,
+				CEB772F1CD2E64A93211D413F991E158 /* SKClient+Stories.h */,
+				9AAF0F4CF61FEBE5F27F076EE43534B6 /* SKClient+Stories.m */,
+			);
+			path = Networking;
+			sourceTree = "<group>";
+		};
+		EB3F31200506B4EC0BAB38AC0E45DC53 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				7C240829368A1DC3E8EE782EEAF704A0 /* Mantle.framework */,
+				85DFBBC54289776922F83BCBCC6532F7 /* Pods_SnapchatKit_Example.framework */,
+				9D100EF1DDFEDE0151BADD810E249EF8 /* Pods_SnapchatKit_OSX.framework */,
+				D8762D8E7B4291A96A1D301857929925 /* Pods_SnapchatKit_Tests.framework */,
+				BBFDD148F657EF9DEBA791AE4CA9E411 /* SnapchatKit.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		F403355360BF744BC09ED8683A01EAFA /* Mantle */ = {
+			isa = PBXGroup;
+			children = (
+				59F7C50BC794CD8AE4A522E621CBDEB2 /* Mantle.h */,
+				5B78B5F838295F2C6CCA0316BE4A7C97 /* MTLJSONAdapter.h */,
+				5D6DA22E10B78E607B571F2A55C30EF9 /* MTLJSONAdapter.m */,
+				35985918E56AD9E0C441B57EF60B263E /* MTLModel.h */,
+				21A864CDFDE11D41869495F647850956 /* MTLModel.m */,
+				D917EDD76808D4D21F22960E1DE309C8 /* MTLModel+NSCoding.h */,
+				06373D743A4B8735559065DB34A4D3CF /* MTLModel+NSCoding.m */,
+				14DA7638F179D4435E88DD761A6C54AF /* MTLReflection.h */,
+				6549D674C4BBFC4AE9F553D4ABED4F95 /* MTLReflection.m */,
+				C93DEA42EF984A92E5FFF4F5EA4C4576 /* MTLTransformerErrorHandling.h */,
+				B0B3A02E4506C7059D914FEF250427E1 /* MTLTransformerErrorHandling.m */,
+				18B61B312FEA02DCE16514E7C4A29FBA /* MTLValueTransformer.h */,
+				30966F6B3985DE33FEB91E8D08220629 /* MTLValueTransformer.m */,
+				06531AAEF120FF70E927F40F0A61C49D /* NSArray+MTLManipulationAdditions.h */,
+				B29E8F6A2790D070998F9CF5CF7EE4D1 /* NSArray+MTLManipulationAdditions.m */,
+				A3A065B43F6F4A3AB98235E4C41E9E6A /* NSDictionary+MTLJSONKeyPath.h */,
+				7DF9455276C69ACF288FDCEEB316B212 /* NSDictionary+MTLJSONKeyPath.m */,
+				DF085137EB0F35B5B37260EABF2BC4FF /* NSDictionary+MTLManipulationAdditions.h */,
+				2B9085E7485D99346EF2A43B26F8F498 /* NSDictionary+MTLManipulationAdditions.m */,
+				DCD2256F10F763F211E4C0CA353ABC10 /* NSDictionary+MTLMappingAdditions.h */,
+				53DAF85FA8CA77FA6432DD4E4865FA28 /* NSDictionary+MTLMappingAdditions.m */,
+				4A4992617DD257BF87C19BD4E5A7D2A9 /* NSError+MTLModelException.h */,
+				A3B3600563469E165A512779D2952B19 /* NSError+MTLModelException.m */,
+				90E3A46DADAE808ABCF8DA093A1F0A37 /* NSObject+MTLComparisonAdditions.h */,
+				452A825C1C9779653BE134C643213E98 /* NSObject+MTLComparisonAdditions.m */,
+				58BA9F3FC2DC449A0D601CAFBB661733 /* NSValueTransformer+MTLInversionAdditions.h */,
+				1FDC119599936009F4BBDAE2B034A189 /* NSValueTransformer+MTLInversionAdditions.m */,
+				FB0E1FAC0060ECAB08CEE29646BFE32A /* NSValueTransformer+MTLPredefinedTransformerAdditions.h */,
+				A7E0035C4D44DD28CDC29DBEE88C9580 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */,
+				7EEDB97D38672F83D2C1631F3806ACC1 /* extobjc */,
+				7196FB889A458E9519E4610F6AF098E8 /* Support Files */,
+			);
+			path = Mantle;
+			sourceTree = "<group>";
+		};
+		F8C9B23DBD87B6B55788CED127E650F3 /* Pods-SnapchatKit-OSX */ = {
+			isa = PBXGroup;
+			children = (
+				0C32BF92B3737BAB4293CB02DDD4B945 /* Info.plist */,
+				A47D5FB068E59938BD8CA832F286CBD7 /* Pods-SnapchatKit-OSX.modulemap */,
+				60324F862519F4C0542AB20FED27482B /* Pods-SnapchatKit-OSX-acknowledgements.markdown */,
+				E37D0CF02FAE213B04ECCF59E1F09308 /* Pods-SnapchatKit-OSX-acknowledgements.plist */,
+				34BB852EFABC59BAFCA45806008FB3B0 /* Pods-SnapchatKit-OSX-dummy.m */,
+				1B42D1B26321D48FD90287E53408FBAD /* Pods-SnapchatKit-OSX-frameworks.sh */,
+				8AD43FC9D3F58696526A320EAEDAF192 /* Pods-SnapchatKit-OSX-resources.sh */,
+				1DC3BE7BB86B644F4B88640AA93A535C /* Pods-SnapchatKit-OSX-umbrella.h */,
+				B178E7B7DF86E0DBEE7A51DB140F29A3 /* Pods-SnapchatKit-OSX.debug.xcconfig */,
+				CDEAC9BF0BF4585523A58300F58B3CDD /* Pods-SnapchatKit-OSX.release.xcconfig */,
 			);
 			name = "Pods-SnapchatKit-OSX";
 			path = "Target Support Files/Pods-SnapchatKit-OSX";
 			sourceTree = "<group>";
 		};
+		F9D32B222D2EB45C67B89BC4030E6B7F /* Targets Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				F8C9B23DBD87B6B55788CED127E650F3 /* Pods-SnapchatKit-OSX */,
+				4B1CC94A88B569D36BA4824B58A6A7F8 /* Pods-SnapchatKit_Example */,
+				25E357B009931E2CB3584CA4E5C25B12 /* Pods-SnapchatKit_Tests */,
+			);
+			name = "Targets Support Files";
+			sourceTree = "<group>";
+		};
+		FF466D3B3F9D1124E4C5FD18BACF7E5C /* Development Pods */ = {
+			isa = PBXGroup;
+			children = (
+				8E9DCF51AF082C910D7DB288BECDBE04 /* SnapchatKit */,
+			);
+			name = "Development Pods";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		00C08140D9A2BF92C9346A9E /* Headers */ = {
+		0EB77D5B0DB0A2C1082D9B9EBD602BF8 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6344AE8E0B2148C2AD213F99 /* Pods-SnapchatKit_Tests-umbrella.h in Headers */,
+				5C29A130746FB6D5E84BDBBBF3959E8F /* AbstractMessage.h in Headers */,
+				6B06F02EAB08ABD063C624BC18BA5440 /* AbstractMessageBuilder.h in Headers */,
+				D282D374F9873392A05853818A6D5B0E /* Attestation.pb.h in Headers */,
+				D1E0716F92E6511E55B5B96ED4AEC4C8 /* Bootstrap.h in Headers */,
+				D1C5FB6E0C236942AFE5AAA5AAFF5655 /* CodedInputStream.h in Headers */,
+				67406B8865F4919851BAC6BEA7A0B167 /* CodedOutputStream.h in Headers */,
+				9121F000E62DE87B8CF8DA11EA769789 /* ConcreteExtensionField.h in Headers */,
+				7787D715B0932EC381A7A217503C81D3 /* crypt.h in Headers */,
+				D5BD3AA4063590F4A80ED47C0369EFA1 /* Descriptor.pb.h in Headers */,
+				8A54A95F2FD1C095901A65A071A5F730 /* ExtendableMessage.h in Headers */,
+				8482FA643C417D3346126983B1CE2163 /* ExtendableMessageBuilder.h in Headers */,
+				6ABE31A4D998B09A454798764523FD90 /* ExtensionField.h in Headers */,
+				86319C7A3EED59A06A3A15D78B09693B /* ExtensionRegistry.h in Headers */,
+				4B738E80961B996C8537CB3576F3770C /* Field.h in Headers */,
+				D166AC5F574F281F986AE8225F7C894D /* ForwardDeclarations.h in Headers */,
+				EBA05579591C2B62DABA4CEE0F877FD7 /* GeneratedMessage.h in Headers */,
+				49A4D5AABC8F459CEA366B311579E804 /* GeneratedMessageBuilder.h in Headers */,
+				F18511E4DF971F9AF0462EF1164F88E9 /* ioapi.h in Headers */,
+				720495FE298D1E150AD5D7841C6CDABB /* Message.h in Headers */,
+				25AE841809F8AB20D9F55F85861DA349 /* MessageBuilder.h in Headers */,
+				478331EF4720256BB0BE0CC2A960105C /* MutableExtensionRegistry.h in Headers */,
+				0C76554583B90F6209F6C1C71908B250 /* MutableField.h in Headers */,
+				77750DA27BF7879D82B4EE3D52E43510 /* mztools.h in Headers */,
+				3E29BB9178E4EDFADCF80C9CD5AD83DD /* NSArray+SnapchatKit.h in Headers */,
+				8CFA5839CA58FB25CBD751B76D8AA86A /* NSData+SnapchatKit.h in Headers */,
+				6B5ADCF1533B10E43C05B60BC9C49316 /* NSDictionary+SnapchatKit.h in Headers */,
+				EA882E0938950C8981FDC2CD09D2E905 /* NSString+SnapchatKit.h in Headers */,
+				DBD779589C0EEF217F9BD85A4488DF71 /* ObjectivecDescriptor.pb.h in Headers */,
+				58195726FB28C876AA88993C0608A124 /* PBArray.h in Headers */,
+				756522082454C73D6E179A6557165875 /* Pods-SnapchatKit_Example-SnapchatKit-umbrella.h in Headers */,
+				59D16357DA752F9CFC22A28282493B48 /* ProtocolBuffers.h in Headers */,
+				A2592BA00080A783E4E6AC1AE915C314 /* RingBuffer.h in Headers */,
+				C0EA1387BAA8FF2AD0E93B2F5E2AEC07 /* SKAddedFriend.h in Headers */,
+				5F6B760329332CC1E215AD30A4471714 /* SKBlob.h in Headers */,
+				B0C4CE31D4BA47F6DF5A10AC79DC3A6A /* SKCashTransaction.h in Headers */,
+				C439369054238B8A0E00645EDEAF398F /* SKClient+Account.h in Headers */,
+				C9388804DD7EF158C738FB4F08259FDD /* SKClient+Chat.h in Headers */,
+				26A8FB84B0F7ACB0C5403E4A920A0881 /* SKClient+Device.h in Headers */,
+				F8FDA8D22AC9594294EB4F2E6FBC001A /* SKClient+Discover.h in Headers */,
+				EB65D934E0D62C636CE934DA5C9A7D04 /* SKClient+Friends.h in Headers */,
+				DA14ED2CE15397202863A58835616AE0 /* SKClient+Snaps.h in Headers */,
+				DCBC7AE273C3D00ED094C5FA527956CA /* SKClient+Stories.h in Headers */,
+				A157A724B33E65EF87E114BD4E759500 /* SKClient.h in Headers */,
+				915FB623F1795824405471A9F6BA53F1 /* SKConversation.h in Headers */,
+				D5FD3875D218393CAEB9EAC42B85C903 /* SKFilter.h in Headers */,
+				1A704361620477DAB19E6EBD967D8F24 /* SKFoundFriend.h in Headers */,
+				77B17F032EAA511415272130D4FFE432 /* SKLocation.h in Headers */,
+				2C5E77D721BF52522874B95F79773870 /* SKMessage.h in Headers */,
+				3F894393B28EA3C7C553B89DDADD20B6 /* SKNearbyUser.h in Headers */,
+				E851FB1E0A716412B039FCA19CA6FB83 /* SKNewConversation.h in Headers */,
+				0CC5E979EB52B9966F2B4E18315DBDC0 /* SKRequest.h in Headers */,
+				86A7957E1DB85234A4BBA94F8CE796A4 /* SKSession.h in Headers */,
+				FD565BCC15825600FA0591835CA5E334 /* SKSharedStoryDescription.h in Headers */,
+				6563A9DA69FA273918AE1C64F500EACB /* SKSimpleUser.h in Headers */,
+				6E75134A2ACEC14C584EEE97B258BB55 /* SKSnap.h in Headers */,
+				065BB6D4330B794A98798E58C47C06E9 /* SKSnapOptions.h in Headers */,
+				800B2ECD46D46FC159315AF31AF610B8 /* SKSnapResponse.h in Headers */,
+				473B0B374FDCED388C3F0E90450D56FA /* SKStory.h in Headers */,
+				3BB491836714DEA80919FA7F4CBB3586 /* SKStoryCollection.h in Headers */,
+				FC8BEEADCF2C29AAB4480DDF78D3161C /* SKStoryNote.h in Headers */,
+				3DAB7FA1643B395E29020DF3DB043FB4 /* SKStoryOptions.h in Headers */,
+				4B7A423CFE94D79D0D1602FA8F3541C2 /* SKStoryUpdater.h in Headers */,
+				8B75EDAFEAD28F8D92FE8216A16888FC /* SKThing.h in Headers */,
+				DBE0F807498A272A78CD08294B24ACEA /* SKUser.h in Headers */,
+				DF81798C84C2D3E1DF580686635F9669 /* SKUserStory.h in Headers */,
+				C253F506F8C862B9018A0587DB20A7E0 /* SnapchatKit-Constants.h in Headers */,
+				C645928E34D41BA10A71023575AF62E7 /* SnapchatKit.h in Headers */,
+				CFE6FA04E3BA20BAAA7D29D16E21DFB7 /* SSZipArchive.h in Headers */,
+				327FB4E32BA8FA11A5AA93494478E623 /* TextFormat.h in Headers */,
+				285A44F32981BF111E7B69389A567FBC /* UnknownFieldSet.h in Headers */,
+				A6DB9B2A5EBA640EC7ABDE1CDF72CFCC /* UnknownFieldSetBuilder.h in Headers */,
+				D4981261FDC830FB300EAB1622BD0870 /* unzip.h in Headers */,
+				35D830851654D766CF88256978A23C1F /* Utilities.h in Headers */,
+				0BCF2760E68800780670F754593FD6D8 /* WireFormat.h in Headers */,
+				878704AEA48E0CC2EB5587E0CE833CF4 /* zip.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		4045D0759AC1A327092F8C3A /* Headers */ = {
+		1F4BCC2B349ED5D0DE2AE6F92083E3F8 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				EB1E8E81D94CF057475F014D /* AbstractMessage.h in Headers */,
-				A85626E4ED29E3BB674FBCA5 /* AbstractMessageBuilder.h in Headers */,
-				D6889A87AC6447CBC7E8F0DA /* Attestation.pb.h in Headers */,
-				C6C4AE550184D5DE8D20EAD3 /* Bootstrap.h in Headers */,
-				6B099A244F1A4DC3F81D39DC /* CodedInputStream.h in Headers */,
-				3E7B7B4F2C1BD392B7EE4097 /* CodedOutputStream.h in Headers */,
-				76CFA3E5EB0B4045C3315F83 /* ConcreteExtensionField.h in Headers */,
-				5B7461D9762C96AA9F885F7C /* Descriptor.pb.h in Headers */,
-				948D462CECAEAA00FDDE82B8 /* ExtendableMessage.h in Headers */,
-				D98614A336F0F115FFA4E70E /* ExtendableMessageBuilder.h in Headers */,
-				51E18CC0CF4E4BFCEC46AAE1 /* ExtensionField.h in Headers */,
-				172C229739F21656C12499C0 /* ExtensionRegistry.h in Headers */,
-				FA83F5BE58CBF6007F5A5572 /* Field.h in Headers */,
-				B96BAB1FF1CFA4761D105B57 /* ForwardDeclarations.h in Headers */,
-				743338848BB23E48AAA68AA4 /* GeneratedMessage.h in Headers */,
-				0592B5F45B102056FEBFFCA9 /* GeneratedMessageBuilder.h in Headers */,
-				BC4E14FBDCBBB4AA22994DFA /* Message.h in Headers */,
-				698A388303485E89AA5E7E62 /* MessageBuilder.h in Headers */,
-				FCFC02D641592E6A98754741 /* MutableExtensionRegistry.h in Headers */,
-				D0CAA80CCE05545EC3EE81DA /* MutableField.h in Headers */,
-				F5F4A19800FECE5199FE2942 /* NSArray+SnapchatKit.h in Headers */,
-				5A373D7A27930DCCC86D125B /* NSData+SnapchatKit.h in Headers */,
-				33D38026929EF2F520145538 /* NSDictionary+SnapchatKit.h in Headers */,
-				1413663A4CB8D03E1B821481 /* NSString+SnapchatKit.h in Headers */,
-				52ACE1B20DF8D17424EC8FB1 /* ObjectivecDescriptor.pb.h in Headers */,
-				BC06764A0C9856B8E2BC314D /* PBArray.h in Headers */,
-				28DE9E6986291322987F2C5D /* Pods-SnapchatKit_Example-SnapchatKit-umbrella.h in Headers */,
-				00F407C5EB2EA7F955BCEABF /* ProtocolBuffers.h in Headers */,
-				E17BC1EE00EE3402ACFB34FE /* RingBuffer.h in Headers */,
-				8121979E3B0028D51D1E7A42 /* SKAddedFriend.h in Headers */,
-				46C648FFE943323327B87AF8 /* SKBlob.h in Headers */,
-				BBB953F2C07608BC8F6A2923 /* SKCashTransaction.h in Headers */,
-				AD25763BBE8EB607A030CB90 /* SKClient+Account.h in Headers */,
-				D1223C3FD1E7BCEBAB80391D /* SKClient+Chat.h in Headers */,
-				4B659BE8421CB710C5AD046C /* SKClient+Device.h in Headers */,
-				6B2A82CF0AE453844C7FC6D1 /* SKClient+Discover.h in Headers */,
-				0A641B5357EEB3E90D3A235B /* SKClient+Friends.h in Headers */,
-				15631C36FA1E1C7CB370C69F /* SKClient+Snaps.h in Headers */,
-				8BBABED701E56C76FADB8093 /* SKClient+Stories.h in Headers */,
-				7F09D4189868DEA572DDD9EF /* SKClient.h in Headers */,
-				9B08F940FD85FEAB7BD42D06 /* SKConversation.h in Headers */,
-				DA569D88C05692114AB9084B /* SKFilter.h in Headers */,
-				2C3473BFF27D0E6A0FC82815 /* SKFoundFriend.h in Headers */,
-				E1540AD6343234037C030B58 /* SKLocation.h in Headers */,
-				F47C27AD219414834E3A70C9 /* SKMessage.h in Headers */,
-				4CAD2371504A623AA8572F91 /* SKNearbyUser.h in Headers */,
-				486D421873C1B9EB84545DE9 /* SKNewConversation.h in Headers */,
-				B121C96D6C53B26DBF092336 /* SKRequest.h in Headers */,
-				AB53B3893F6AE15899C49133 /* SKSession.h in Headers */,
-				29BC621D79114AB88D4F3786 /* SKSharedStoryDescription.h in Headers */,
-				11EB7D51AFD16587C94D84E2 /* SKSimpleUser.h in Headers */,
-				6CE8D42C300780F1E60058FE /* SKSnap.h in Headers */,
-				986C7B2B29F2654B112BFDC4 /* SKSnapOptions.h in Headers */,
-				74AA33D29C0139BE8668A1D2 /* SKSnapResponse.h in Headers */,
-				24AC4CC0E5A1B56812826111 /* SKStory.h in Headers */,
-				1E3D15AF006295CEB3060ACB /* SKStoryCollection.h in Headers */,
-				480EC581AA37FC8B7F6BE7D7 /* SKStoryNote.h in Headers */,
-				DC4F9A4C898754729A52C9B2 /* SKStoryOptions.h in Headers */,
-				A801A72F7F90D1BF04BD6E78 /* SKStoryUpdater.h in Headers */,
-				B7070ED6FB7CB05A09889145 /* SKThing.h in Headers */,
-				50C75D1CDB8FE9CE73B70737 /* SKUser.h in Headers */,
-				C2350014B021DA0EB009B556 /* SKUserStory.h in Headers */,
-				CBCEC0BBA7D785AB6BE692B8 /* SSZipArchive.h in Headers */,
-				A8C2B67DAC1EED2524ED0747 /* SnapchatKit-Constants.h in Headers */,
-				E84AC9A52EFC9B6AC7D05864 /* SnapchatKit.h in Headers */,
-				B8F14AB0C53E0A3F6F4BE91D /* TextFormat.h in Headers */,
-				5376161389203A8367405598 /* UnknownFieldSet.h in Headers */,
-				BEAAADF2611C76AFF198731C /* UnknownFieldSetBuilder.h in Headers */,
-				3E804385D91DCA559F4A05CA /* Utilities.h in Headers */,
-				CB1994B2052C811C3754538C /* WireFormat.h in Headers */,
-				B66868E9085D0BC5B40B1175 /* crypt.h in Headers */,
-				F4CA0FCE7713A68EC29CDF10 /* ioapi.h in Headers */,
-				A425020C8D1C6E79BEA8345B /* mztools.h in Headers */,
-				854D8D6ABABF603B3E69F82D /* unzip.h in Headers */,
-				227E068AC23CD9EC5B781563 /* zip.h in Headers */,
+				4D082797F8372F97CE32A2348F67FBD1 /* EXTKeyPathCoding.h in Headers */,
+				31E7338BAEC9D179702663B3590EFBC2 /* EXTRuntimeExtensions.h in Headers */,
+				3E7A470C6E7EE8CD1C53D90579C63E24 /* EXTScope.h in Headers */,
+				091822D8E56D1D6FE6840674A4F12ADD /* Mantle.h in Headers */,
+				C163572BA817FF6475CA9D3628ABB3DA /* metamacros.h in Headers */,
+				83B2581466924E92C1A63FA109400294 /* MTLJSONAdapter.h in Headers */,
+				82322A79FF610A7A075BE4404714E3C4 /* MTLModel+NSCoding.h in Headers */,
+				0053DA2124C8A670D3F7EEF7993E81CD /* MTLModel.h in Headers */,
+				9D3895FEB26B81C4B54BAF5888624EAA /* MTLReflection.h in Headers */,
+				6EEAE3619B32B34D36ED8AA78DB1A0CA /* MTLTransformerErrorHandling.h in Headers */,
+				3DC3166DBA145A9B1A72D3D0E833404D /* MTLValueTransformer.h in Headers */,
+				A95A1AE1DE0E8B75BF1A203BFFAC2595 /* NSArray+MTLManipulationAdditions.h in Headers */,
+				E0EDEDBD0C23C8846BE28771D2A09854 /* NSDictionary+MTLJSONKeyPath.h in Headers */,
+				D6863811354E312C7D4DDEED87509657 /* NSDictionary+MTLManipulationAdditions.h in Headers */,
+				32562F5973360621D7CA56CDF47BBCBD /* NSDictionary+MTLMappingAdditions.h in Headers */,
+				7E6FC74BD1EA51F8CBFEBD4F1AF2091E /* NSError+MTLModelException.h in Headers */,
+				ADEC9C941BFB1070DF9545CD1EEFA9C8 /* NSObject+MTLComparisonAdditions.h in Headers */,
+				B97B55B25D25910CDEE35D46EE8CED75 /* NSValueTransformer+MTLInversionAdditions.h in Headers */,
+				48D9F27D1DF186EEC82DC1323FBDC8BC /* NSValueTransformer+MTLPredefinedTransformerAdditions.h in Headers */,
+				7B985DA5AD90B39433D3D9A6861B640F /* Pods-SnapchatKit-OSX-Mantle-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		5C90B73A4DC5486210CB5D32 /* Headers */ = {
+		21852BF36A7404DC880114FD130AB269 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0FFDA0ABCDC7D78ABA284CFF /* EXTKeyPathCoding.h in Headers */,
-				B4E0BFDEC1FB9CB556200F19 /* EXTRuntimeExtensions.h in Headers */,
-				F51C21345F82495EE745B0D6 /* EXTScope.h in Headers */,
-				AECE9F0E649E37204F298ABC /* MTLJSONAdapter.h in Headers */,
-				55BEBECB11A566F84D6ACDFD /* MTLModel+NSCoding.h in Headers */,
-				549FC1A5B80D8A12B02055D2 /* MTLModel.h in Headers */,
-				1272BDE2A1CB62E9B4FB21C9 /* MTLReflection.h in Headers */,
-				059BB8BF576C6A543361734B /* MTLTransformerErrorHandling.h in Headers */,
-				2CBF903CBF1B97B9B944E63F /* MTLValueTransformer.h in Headers */,
-				1E29F150246CEDA360EB6F39 /* Mantle.h in Headers */,
-				AFB73EF9CD3A61FF120032CD /* NSArray+MTLManipulationAdditions.h in Headers */,
-				1949E7BEB3C4CB4E5FAE92D2 /* NSDictionary+MTLJSONKeyPath.h in Headers */,
-				617D3D3FEDD53C229199D369 /* NSDictionary+MTLManipulationAdditions.h in Headers */,
-				5332A70E9EA896599F37F098 /* NSDictionary+MTLMappingAdditions.h in Headers */,
-				F838815AA0D9E34FA3551B7A /* NSError+MTLModelException.h in Headers */,
-				DBE9EABF86018C62F834BA03 /* NSObject+MTLComparisonAdditions.h in Headers */,
-				5C164DCB636CD888466BABA6 /* NSValueTransformer+MTLInversionAdditions.h in Headers */,
-				12AB2A8AE1D927851B2F98F6 /* NSValueTransformer+MTLPredefinedTransformerAdditions.h in Headers */,
-				B3ED9A6964AF2E38FBA5FF4D /* Pods-SnapchatKit_Example-Mantle-umbrella.h in Headers */,
-				7CB5BD6859D70E2152116676 /* metamacros.h in Headers */,
+				16B2AA343067DCAD6CD1BED7DBC6287A /* EXTKeyPathCoding.h in Headers */,
+				5EE6F04CE8A0187799937EBBF2126350 /* EXTRuntimeExtensions.h in Headers */,
+				40C077799222167288A2ABC1F56CAF16 /* EXTScope.h in Headers */,
+				D96F3348897EB52002398839CF6407BF /* Mantle.h in Headers */,
+				8949D2527E61AA5087E196CD4547FC98 /* metamacros.h in Headers */,
+				471BC7DC8B0FABD32EAF770E8D686EB6 /* MTLJSONAdapter.h in Headers */,
+				CF2FDC3BE87FF50F5030F93491656E0E /* MTLModel+NSCoding.h in Headers */,
+				92789D62469A30E60FA89AB348E37E2D /* MTLModel.h in Headers */,
+				285286FE8C7219404AE1AA0A97E12410 /* MTLReflection.h in Headers */,
+				908A58094D68486876A366AFC5589582 /* MTLTransformerErrorHandling.h in Headers */,
+				74A9C7F9256BE4D04B6BF797A464F16C /* MTLValueTransformer.h in Headers */,
+				E94DA6BC5D83F8BF9762B3F908DFDB28 /* NSArray+MTLManipulationAdditions.h in Headers */,
+				FD57BB6E523BDF45449940906AF33A62 /* NSDictionary+MTLJSONKeyPath.h in Headers */,
+				881FB8FA6D215FEB9E3D7B342B969A0E /* NSDictionary+MTLManipulationAdditions.h in Headers */,
+				3B6759AA51ECB4A6563506707FE654FA /* NSDictionary+MTLMappingAdditions.h in Headers */,
+				2374F497E8C89CB6D8C49233C14F4DC9 /* NSError+MTLModelException.h in Headers */,
+				8369D6BE3B24E83F01D6B117792A1C68 /* NSObject+MTLComparisonAdditions.h in Headers */,
+				4AD59595C51B3FC7C7469B926AB0EED5 /* NSValueTransformer+MTLInversionAdditions.h in Headers */,
+				65C3BB92487BB24C522222F5FA511BD8 /* NSValueTransformer+MTLPredefinedTransformerAdditions.h in Headers */,
+				DF26D63341C55884A5ECB643D272B330 /* Pods-SnapchatKit_Tests-Mantle-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		7AB03A482E493F5AA146DFDB /* Headers */ = {
+		6DD736F2F6D42D1A7ED1CC48403A5BB4 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5CF80F721AF87A2540F0DDAE /* Pods-SnapchatKit-OSX-umbrella.h in Headers */,
+				291074E3CE3F4E7C5A5B24788B18FDB4 /* Pods-SnapchatKit_Example-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		9D1934C218752DF842BC1B23 /* Headers */ = {
+		A1C6710EBFFB1E1509507121401D7FEA /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F9EDC541D1A757F6AB8387A4 /* AbstractMessage.h in Headers */,
-				39C9AF5FA6D05B16392FB5A8 /* AbstractMessageBuilder.h in Headers */,
-				F749139596CF9D5F6CCBE6C1 /* Attestation.pb.h in Headers */,
-				6C3B5FCF95765E60FAB3DDC3 /* Bootstrap.h in Headers */,
-				28B73A25E281BCA1914A2BC3 /* CodedInputStream.h in Headers */,
-				0F3E66D7D81AC8F0BFC8B580 /* CodedOutputStream.h in Headers */,
-				B108138366AF5D0BF380F21B /* ConcreteExtensionField.h in Headers */,
-				1A32E594FF1F5FDDF20566F9 /* Descriptor.pb.h in Headers */,
-				5F1C9BF96C16E4DDF4211650 /* ExtendableMessage.h in Headers */,
-				E49996EB3A48A189582F9479 /* ExtendableMessageBuilder.h in Headers */,
-				EABE383C749FEFD859EA1449 /* ExtensionField.h in Headers */,
-				1D6D709CAAD55DA400ED60D5 /* ExtensionRegistry.h in Headers */,
-				E6A3509F0C15CC93FA130319 /* Field.h in Headers */,
-				B23D03813A7C5BB065EA6B7A /* ForwardDeclarations.h in Headers */,
-				81BB9979F15ADBF4D54D2B6E /* GeneratedMessage.h in Headers */,
-				578204BBCA8628A0B524BA5E /* GeneratedMessageBuilder.h in Headers */,
-				DCA52ACE15C079DEB170037B /* Message.h in Headers */,
-				BDA1BB7FE4B35AE0DBE962FD /* MessageBuilder.h in Headers */,
-				4C5A393E54055B0D535FF7C5 /* MutableExtensionRegistry.h in Headers */,
-				3248725B93BF6B53EB590A4F /* MutableField.h in Headers */,
-				C2C500C4791C90477A06702D /* NSArray+SnapchatKit.h in Headers */,
-				F15F3D33AECBA0423B371DE1 /* NSData+SnapchatKit.h in Headers */,
-				8F99E1FB81BE65EAD3BFBD2E /* NSDictionary+SnapchatKit.h in Headers */,
-				398CC926F5BD25EBEE7AC536 /* NSString+SnapchatKit.h in Headers */,
-				B038E6A1C35A2FD5706664C8 /* ObjectivecDescriptor.pb.h in Headers */,
-				FE36B81BDFA3AD2CB6AE9675 /* PBArray.h in Headers */,
-				F7C3DED1FC494C7C2E0EC3D5 /* Pods-SnapchatKit-OSX-SnapchatKit-umbrella.h in Headers */,
-				CB6B7B14A54515F9FDA04CB0 /* ProtocolBuffers.h in Headers */,
-				77A18B03292BF020A78F2D73 /* RingBuffer.h in Headers */,
-				1BEE0A4B7B923E1F21A48FFA /* SKAddedFriend.h in Headers */,
-				2FD2E6238E459614CF6BA1F3 /* SKBlob.h in Headers */,
-				78E3F8BFDF69D3BC6E224C87 /* SKCashTransaction.h in Headers */,
-				3C58B90EC95D736ED534FCA6 /* SKClient+Account.h in Headers */,
-				8D4C6F8B84F09B604C58B72B /* SKClient+Chat.h in Headers */,
-				0545D625AA44EAFAC518F9BB /* SKClient+Device.h in Headers */,
-				FA4B2D5C3C66E59FEE6A4A4D /* SKClient+Discover.h in Headers */,
-				A0A6E92758A1310817B63D11 /* SKClient+Friends.h in Headers */,
-				6D6FDF00ADF44F0A7CD7BBD4 /* SKClient+Snaps.h in Headers */,
-				10B746F3D906A087DF30A582 /* SKClient+Stories.h in Headers */,
-				D13B0963192862526CC0B0C6 /* SKClient.h in Headers */,
-				3B695192D0D479B8D41DDE1F /* SKConversation.h in Headers */,
-				0194FA76F657F16C21C55A80 /* SKFilter.h in Headers */,
-				E6F61869F8D45E4A234FF58B /* SKFoundFriend.h in Headers */,
-				0FF4A7B67045536EE656FA60 /* SKLocation.h in Headers */,
-				2075D5A637A1ED065D56794E /* SKMessage.h in Headers */,
-				3970F072825457A518B06022 /* SKNearbyUser.h in Headers */,
-				2350F671A248F17D4A961069 /* SKNewConversation.h in Headers */,
-				CEB4C095D7E10C49CCDD568A /* SKRequest.h in Headers */,
-				C48C586F1945E55235C497ED /* SKSession.h in Headers */,
-				BEF1E497350B92BEBC4EC3A1 /* SKSharedStoryDescription.h in Headers */,
-				29D3BA19FAC789BE04FFC46C /* SKSimpleUser.h in Headers */,
-				87A6F25731BD3F71C1A37887 /* SKSnap.h in Headers */,
-				553FC487B0E329BD1564216E /* SKSnapOptions.h in Headers */,
-				FB706A9DDF2864D39B4CA86D /* SKSnapResponse.h in Headers */,
-				0F4B0F855BFBF02074C35C69 /* SKStory.h in Headers */,
-				A78B4AB69095486609C94185 /* SKStoryCollection.h in Headers */,
-				2F6250796AABF930BB921FA0 /* SKStoryNote.h in Headers */,
-				AFEFA627888B6C5308D3A516 /* SKStoryOptions.h in Headers */,
-				1854CCB2C5C2D6ACFF7496EE /* SKStoryUpdater.h in Headers */,
-				7825A05C79A0E11D19144990 /* SKThing.h in Headers */,
-				0B3BD1EECDE7DE487A36CAE9 /* SKUser.h in Headers */,
-				8E4E8FC6AD604D3D52214C0C /* SKUserStory.h in Headers */,
-				3AA8BD8C5381018DF5EF91F7 /* SSZipArchive.h in Headers */,
-				905405274F0D710675CED6CF /* SnapchatKit-Constants.h in Headers */,
-				E40B40F4CF10DAC6906D3901 /* SnapchatKit.h in Headers */,
-				9471842034EAE351B3317A83 /* TextFormat.h in Headers */,
-				3D38403CF9EF75026E6BB743 /* UnknownFieldSet.h in Headers */,
-				B97CFDE2A57EFCB2AE6BC211 /* UnknownFieldSetBuilder.h in Headers */,
-				C01E0429813C870987F1E7D7 /* Utilities.h in Headers */,
-				B9C9CE113960D2E0A67543CF /* WireFormat.h in Headers */,
-				F4994BF7DD20E029DDDC0F48 /* crypt.h in Headers */,
-				E1514D9F0EA440C86673EC93 /* ioapi.h in Headers */,
-				18A3D5CBDDF4B83AE292D1C3 /* mztools.h in Headers */,
-				F496F281029507E98B199D3C /* unzip.h in Headers */,
-				3EE3B22425A0AD7CCE863F6C /* zip.h in Headers */,
+				05735D40AC69A1FBBDD5DF622B479835 /* AbstractMessage.h in Headers */,
+				9FE7CB5B685FDB50EAE1A50C5F72AE44 /* AbstractMessageBuilder.h in Headers */,
+				E5E105928FA9936BAE93F7876C13C6C5 /* Attestation.pb.h in Headers */,
+				39EA28C03534E3CF349C04D02204C43F /* Bootstrap.h in Headers */,
+				1107E4CBC86BF83F18245209D524D8F5 /* CodedInputStream.h in Headers */,
+				755D208883C9A23974BC2A4D501F9627 /* CodedOutputStream.h in Headers */,
+				2C36FC399C44B70FA6EB83E7FE3B585D /* ConcreteExtensionField.h in Headers */,
+				B0D9197026A81388B71196FFF4D5BB06 /* crypt.h in Headers */,
+				0896BADCF11D56EFB35F8EBA7AD68059 /* Descriptor.pb.h in Headers */,
+				CCDC21DA0FAB1837A8D4D94E3051457E /* ExtendableMessage.h in Headers */,
+				57350D4D2FBA84A8EF0A057F18C028E2 /* ExtendableMessageBuilder.h in Headers */,
+				4B437DA6250F337A5596D4719DBAA722 /* ExtensionField.h in Headers */,
+				FA281CFC8D23630C6298B85EB2067212 /* ExtensionRegistry.h in Headers */,
+				9BD952A5A55EBB202F43317F9835BD07 /* Field.h in Headers */,
+				A287CC2E728344F3FA6D92F230D2B4E5 /* ForwardDeclarations.h in Headers */,
+				2AAB06CEF6C7D4BBB7D06BD2993EF2D1 /* GeneratedMessage.h in Headers */,
+				DAF7AF94D28CAFD1ED64657BAFF890D4 /* GeneratedMessageBuilder.h in Headers */,
+				9868A999F686B77A09B2F5E1451115A4 /* ioapi.h in Headers */,
+				81153517E47875ECCC70490FB290980A /* Message.h in Headers */,
+				D77A715DAD8A1C776CD34C1139CB8B20 /* MessageBuilder.h in Headers */,
+				14D34F80BF1B9C568BCB71A93D9ABAF8 /* MutableExtensionRegistry.h in Headers */,
+				080A566E7AD4F2B01E74EF2A7DEA64A5 /* MutableField.h in Headers */,
+				A179FCC27048DC3FDEB966BAB5CAF63A /* mztools.h in Headers */,
+				7DB4E5D0DDEABF686A3A81C9120774AB /* NSArray+SnapchatKit.h in Headers */,
+				93769114AF59E54CED8772DAD7EDC30F /* NSData+SnapchatKit.h in Headers */,
+				E4B95563FE886803F236930DF455AC2F /* NSDictionary+SnapchatKit.h in Headers */,
+				82946214B08EC20BF2FB024EFBF99340 /* NSString+SnapchatKit.h in Headers */,
+				243D3B86A9A67DEFD0BDCEE4D6C7D839 /* ObjectivecDescriptor.pb.h in Headers */,
+				0F2D519BD6C421E07B3026992381A769 /* PBArray.h in Headers */,
+				EC947AED5B1095A376BDC2CFE21DDCDD /* Pods-SnapchatKit_Tests-SnapchatKit-umbrella.h in Headers */,
+				7C18CDA8B0EBA841F87ABB1611FF8B20 /* ProtocolBuffers.h in Headers */,
+				00E35003DE132CA79A526FCE89D77E16 /* RingBuffer.h in Headers */,
+				6DC4D8028691675D145D45CA04008AEF /* SKAddedFriend.h in Headers */,
+				28EFD06561A33BB46DC2F345BAE48F00 /* SKBlob.h in Headers */,
+				89ABF1D2530B99C2267887C1689242AB /* SKCashTransaction.h in Headers */,
+				39BA0E82CE3772CCB25D8794CB97340D /* SKClient+Account.h in Headers */,
+				82C521B31AAC7DFD5D18E618BFBF06CF /* SKClient+Chat.h in Headers */,
+				D45D9A9623C63E31614320ACE4538E4F /* SKClient+Device.h in Headers */,
+				80AE9C745A522B06E97A31691EBC686D /* SKClient+Discover.h in Headers */,
+				D37ACE9495FF884617BBCD7F3FFE417F /* SKClient+Friends.h in Headers */,
+				787F037EADA4F6E7F5441812EB9DB78B /* SKClient+Snaps.h in Headers */,
+				34140D666739EE70A5CC09E86EA7F79A /* SKClient+Stories.h in Headers */,
+				44F3B511C9F401D8C16800584A31E61B /* SKClient.h in Headers */,
+				5E97AAF2BEE6EBD3FF036F96E52E0161 /* SKConversation.h in Headers */,
+				9D2309809BF676276FF378C25B22D6AE /* SKFilter.h in Headers */,
+				B802D1B39FEEBEE89FD960A80BA90AE2 /* SKFoundFriend.h in Headers */,
+				6C12BAE728E410C79932652980B431FF /* SKLocation.h in Headers */,
+				9388EAE8DD4E0193CFAA60A4F674FE5A /* SKMessage.h in Headers */,
+				E75286444154B5008250E7ABF4A21E44 /* SKNearbyUser.h in Headers */,
+				5BC30758F4D0C0F36B721AE29E3A8C1E /* SKNewConversation.h in Headers */,
+				B34DA3C60AFDAAAEA2C27A5D5C45763D /* SKRequest.h in Headers */,
+				2BAF5FD6442AAAFA815184C991BF5981 /* SKSession.h in Headers */,
+				A5279C159B4D0BFDD022A0BC824B4A41 /* SKSharedStoryDescription.h in Headers */,
+				F560CF8AE9C997FB694C90CFF64E5D14 /* SKSimpleUser.h in Headers */,
+				73606C0786F1540F0BA82FBF2174115F /* SKSnap.h in Headers */,
+				1841924A876FF2571659ECFD3B1EE210 /* SKSnapOptions.h in Headers */,
+				707CC0B1ABAEC59B775DCB7995E91EB1 /* SKSnapResponse.h in Headers */,
+				7DEE744FF90E4E108C01558153BF75FF /* SKStory.h in Headers */,
+				7DB7BEADB3E60310D8E4EA2166130CFB /* SKStoryCollection.h in Headers */,
+				6D69ADC581A6E883B2DFA899DA8723BE /* SKStoryNote.h in Headers */,
+				CC45F5926EDC33CFDEDCA69191042A78 /* SKStoryOptions.h in Headers */,
+				8D4237E557C43F0CF261721C8889AD63 /* SKStoryUpdater.h in Headers */,
+				98DB39B010A26293D6320822C4358726 /* SKThing.h in Headers */,
+				527E54842FB111C7860FFB9DF6FB9480 /* SKUser.h in Headers */,
+				D46E1A27F558BDE48CB9864387E071F4 /* SKUserStory.h in Headers */,
+				267CF5C3C42266B456D26CCB8A6AF099 /* SnapchatKit-Constants.h in Headers */,
+				136C3D9C55DCC9D82F7E5E0159DB7DAE /* SnapchatKit.h in Headers */,
+				ABD235416293C0D6BC8BF36962AABB43 /* SSZipArchive.h in Headers */,
+				67EDC13AA60ABBB65208A5082E762C7F /* TextFormat.h in Headers */,
+				853344F944576EF29BF0925C878D23D8 /* UnknownFieldSet.h in Headers */,
+				D52F21DDC605DA93D427D439E4FCEB02 /* UnknownFieldSetBuilder.h in Headers */,
+				CDFE542F4E6B55DB53B4C16C500C328A /* unzip.h in Headers */,
+				91CE73A494F556301D37BC9F4B69A9BE /* Utilities.h in Headers */,
+				C0C929E4ACF3F3B5708EED5A60383238 /* WireFormat.h in Headers */,
+				54F2E6E1B8A6294B557119AAC804BBA8 /* zip.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A4637771EBC9A99C42C12545 /* Headers */ = {
+		A26D1407F7CF49143A96FA34DB619794 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7D2CB385C94CD9F534ABF670 /* EXTKeyPathCoding.h in Headers */,
-				004FA0B529046958F4B620DB /* EXTRuntimeExtensions.h in Headers */,
-				A227027126993D119E9B36CB /* EXTScope.h in Headers */,
-				6B816E0C33065EB99D14EDF4 /* MTLJSONAdapter.h in Headers */,
-				F905D76F908A1267DEF6D766 /* MTLModel+NSCoding.h in Headers */,
-				99F7A57C6C4B1D5B1E65B27E /* MTLModel.h in Headers */,
-				10BFC08096EED3AFBE874BFF /* MTLReflection.h in Headers */,
-				57D4362A502BEA75B844EE47 /* MTLTransformerErrorHandling.h in Headers */,
-				611D58FC6C7E8C52C04B2A7E /* MTLValueTransformer.h in Headers */,
-				C6540960CCE1833DE9A187E7 /* Mantle.h in Headers */,
-				EFEAFE3EE64FE7D8AED7D36E /* NSArray+MTLManipulationAdditions.h in Headers */,
-				EE2113A634FB1D00B3C430DE /* NSDictionary+MTLJSONKeyPath.h in Headers */,
-				584689C9DDEAE8E320117B0D /* NSDictionary+MTLManipulationAdditions.h in Headers */,
-				96B213BB0D4D147DE253B765 /* NSDictionary+MTLMappingAdditions.h in Headers */,
-				B255621DC1B525331E530359 /* NSError+MTLModelException.h in Headers */,
-				B42683950415442E4BD3609B /* NSObject+MTLComparisonAdditions.h in Headers */,
-				3A6A28EF49EEAF01C8723023 /* NSValueTransformer+MTLInversionAdditions.h in Headers */,
-				8DA97A20569F938904D3387D /* NSValueTransformer+MTLPredefinedTransformerAdditions.h in Headers */,
-				E6B9E9636592B354BEB7E0C5 /* Pods-SnapchatKit-OSX-Mantle-umbrella.h in Headers */,
-				67449BF0401EFDA39FC887ED /* metamacros.h in Headers */,
+				02A7B6428992BB41A044CDFCF0F97B46 /* AbstractMessage.h in Headers */,
+				AF2B8C4FFD7B9FDFBFB1F27C0054ED5C /* AbstractMessageBuilder.h in Headers */,
+				B95738039B80FB553C404FEA1CA843D1 /* Attestation.pb.h in Headers */,
+				601840AF945E6DAD9409D9F4AC0F84D2 /* Bootstrap.h in Headers */,
+				1031F9FEA1EDEE8A92E93180AE933A14 /* CodedInputStream.h in Headers */,
+				2681E46DD69A2B7004A58ADC8E080957 /* CodedOutputStream.h in Headers */,
+				8ED0BD420D3AB8E37C06CFBADABBC5CC /* ConcreteExtensionField.h in Headers */,
+				024CB5A94F8C400B1D9BB8FECD524A98 /* crypt.h in Headers */,
+				2220D5B5B8CD3829AC386924E7077832 /* Descriptor.pb.h in Headers */,
+				7DB938DED1829CCFD49CE5C2D25DE3F5 /* ExtendableMessage.h in Headers */,
+				0B619861F6B430E30337F61DB3F4D4E6 /* ExtendableMessageBuilder.h in Headers */,
+				10426A8D8C4853EB096DF09D705CA7BA /* ExtensionField.h in Headers */,
+				5AE8A38561CDA0A9351FFAC780B75A01 /* ExtensionRegistry.h in Headers */,
+				F1001B8C74D414F6CDC31054A42C1111 /* Field.h in Headers */,
+				8B56ECEF3192D42F101031F657E5A880 /* ForwardDeclarations.h in Headers */,
+				97828A757420065134A817CDE0666A6D /* GeneratedMessage.h in Headers */,
+				CA5E2D8CEEC6C21F914C8FB7749CCA96 /* GeneratedMessageBuilder.h in Headers */,
+				99026B2C8C968E88DEB1D7CEA021F90B /* ioapi.h in Headers */,
+				4E92A504E5A73DF5D5F8FECEFD6E6F9D /* Message.h in Headers */,
+				173F923EC24D6D2DB09D59D434B54C6E /* MessageBuilder.h in Headers */,
+				84AC3B4799877F69BA26022A4074D5A5 /* MutableExtensionRegistry.h in Headers */,
+				A69CF9AB373B5BF54933D4BCBDD24B8A /* MutableField.h in Headers */,
+				E24816B991E55EE80A0B76199812A802 /* mztools.h in Headers */,
+				7D99ECA077EFE880E6E2A0663B9773AD /* NSArray+SnapchatKit.h in Headers */,
+				E73B896247578CA52A5CC132E60CCB9B /* NSData+SnapchatKit.h in Headers */,
+				2E044016AC68BA7C627FF8D226501E9C /* NSDictionary+SnapchatKit.h in Headers */,
+				3D3F06AB744A95368C463750E4B80D62 /* NSString+SnapchatKit.h in Headers */,
+				C934D4DE7B8A6482E32139C0428CE9EE /* ObjectivecDescriptor.pb.h in Headers */,
+				D1465806DEA963CAA3584333FA6D75A7 /* PBArray.h in Headers */,
+				7EDD03E35763A4701C72D2A61971A11D /* Pods-SnapchatKit-OSX-SnapchatKit-umbrella.h in Headers */,
+				49158774B3216C2C8D3D59F20541A290 /* ProtocolBuffers.h in Headers */,
+				3CB7CF2F1075ADA90CB8E5C99602CC79 /* RingBuffer.h in Headers */,
+				099696D740CF3C866F1CC938442BFB2D /* SKAddedFriend.h in Headers */,
+				3E60CF911969ABE43EC3DCA7D33EC161 /* SKBlob.h in Headers */,
+				20BF5F6B9510180FBCB8678A9D06FBC1 /* SKCashTransaction.h in Headers */,
+				9726F338A0C2308D6F9A32F70A2621C3 /* SKClient+Account.h in Headers */,
+				6DE35003B36618C5EDB05378FD3A3D7E /* SKClient+Chat.h in Headers */,
+				FD0B0BB955EDD70593FB790E473C489B /* SKClient+Device.h in Headers */,
+				56FD99CC921A36F3CBC643B498364D87 /* SKClient+Discover.h in Headers */,
+				6EF72229A34E368590361CD0ACD79418 /* SKClient+Friends.h in Headers */,
+				17F5075BD7E38D4E0D1BFE5C19CA3D69 /* SKClient+Snaps.h in Headers */,
+				29A9097F89096BE5EBDCE09AACEDB4DF /* SKClient+Stories.h in Headers */,
+				35497EE619866A2A4DF2311997211129 /* SKClient.h in Headers */,
+				4B394B884B725511E15770EECFE7A593 /* SKConversation.h in Headers */,
+				E430B9441FFAAB0E2B802FC6BFFAA438 /* SKFilter.h in Headers */,
+				D53BA31AD32B6016050C026A2183E05A /* SKFoundFriend.h in Headers */,
+				85DB71B674B21FC4069B3172E010757F /* SKLocation.h in Headers */,
+				978AB5F23A70FD0FFCAE67531BED2BFD /* SKMessage.h in Headers */,
+				BBD51C8B83ED3761DD5A40F120427D25 /* SKNearbyUser.h in Headers */,
+				9C2C9B6ED4A12B7E5EDA5954CE4BE54A /* SKNewConversation.h in Headers */,
+				996AA48FF48E0EF26C5E5317AD160D65 /* SKRequest.h in Headers */,
+				383508FE12C8DCCB754440DC8687ED7A /* SKSession.h in Headers */,
+				6A575A24FA4ABF4977806083C259B579 /* SKSharedStoryDescription.h in Headers */,
+				237F5429A90C1C3874380DFCC7F50349 /* SKSimpleUser.h in Headers */,
+				AE372FF96627076C1B6D8659648C45F4 /* SKSnap.h in Headers */,
+				8A7FBB916C343C830946186B34BCE7A7 /* SKSnapOptions.h in Headers */,
+				8B1FA0EA3807FD8856BDDF29F062748C /* SKSnapResponse.h in Headers */,
+				1CCCE7272B85A744EA4BBFF2A2B1A584 /* SKStory.h in Headers */,
+				F1779AA857C28E41A28CFCAEAE7AB800 /* SKStoryCollection.h in Headers */,
+				A63F55B596C36DC6FAE1916920BA2C4D /* SKStoryNote.h in Headers */,
+				975B8A09DBB1BC1F01181A5A1AC28719 /* SKStoryOptions.h in Headers */,
+				6D0A5F989BECD7803E4C9FCA9E64E663 /* SKStoryUpdater.h in Headers */,
+				2B6A2EAC3A16273CB0DDDF31C678D2AA /* SKThing.h in Headers */,
+				4B1709653D0D99E75F38F9F42FF0933D /* SKUser.h in Headers */,
+				3B4115980D5C8369C944342752FC0C64 /* SKUserStory.h in Headers */,
+				6916DEC99C867F68C2420A0AD0DFA9FA /* SnapchatKit-Constants.h in Headers */,
+				818A50C74A4222067AE1AB8D86B9A24A /* SnapchatKit.h in Headers */,
+				FFE4568A31AC84530AFAE54120EE6EE9 /* SSZipArchive.h in Headers */,
+				403C79DF12E4C2526C9C744766D08957 /* TextFormat.h in Headers */,
+				D1AB726477E70D4EC3B9A717E4D2433F /* UnknownFieldSet.h in Headers */,
+				EEB188DDA5FA84A3833B10075DF8CD60 /* UnknownFieldSetBuilder.h in Headers */,
+				4EB68C418B69373E07B3B1E76E4361FD /* unzip.h in Headers */,
+				5E7EEF8C703DE01F17614CEA0F2BC834 /* Utilities.h in Headers */,
+				8693A017630AD73BE9AE77857D0BB232 /* WireFormat.h in Headers */,
+				2585D6EA8E5FE203C3FC8CB2FEEDF40A /* zip.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A75D8509349614498E942A5E /* Headers */ = {
+		D7009AC30A02C03A4652FC51C9F4337B /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6529D3442D33DC391529BAC1 /* Pods-SnapchatKit_Example-umbrella.h in Headers */,
+				1EB2D4070BDBA437257948E9847CAD45 /* Pods-SnapchatKit_Tests-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		EB279B52A80F029988129D19 /* Headers */ = {
+		DF13AD445F84263F7ABD4E07823E8371 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				18C01EC3370D069753316496 /* AbstractMessage.h in Headers */,
-				646891B8E56D239FD9BA7B0D /* AbstractMessageBuilder.h in Headers */,
-				3CDC1301650AE857C9735D00 /* Attestation.pb.h in Headers */,
-				82EE91123D8CCAC2C1558E81 /* Bootstrap.h in Headers */,
-				FEE928E8D8883C714CBE2194 /* CodedInputStream.h in Headers */,
-				8A1485F41B99AE7111FDBBA6 /* CodedOutputStream.h in Headers */,
-				6B7BADCAF5D27A81763A2175 /* ConcreteExtensionField.h in Headers */,
-				0CE07962AB69F5793566C06A /* Descriptor.pb.h in Headers */,
-				37B19B76DF5EE1635FE3FF52 /* ExtendableMessage.h in Headers */,
-				80462C60BFEACE3C75307F59 /* ExtendableMessageBuilder.h in Headers */,
-				5BA2F898C5F5CF7DF9A5C87D /* ExtensionField.h in Headers */,
-				896058141FA3B9D1470B59D5 /* ExtensionRegistry.h in Headers */,
-				7E14D8E7DA87BCBC8B978052 /* Field.h in Headers */,
-				81A2A5A04991182D22D75265 /* ForwardDeclarations.h in Headers */,
-				274DE44536EC4079EBA66122 /* GeneratedMessage.h in Headers */,
-				36A8BE1A04E94EAE99F9A21E /* GeneratedMessageBuilder.h in Headers */,
-				7EA515CDA613A305F4CD4A69 /* Message.h in Headers */,
-				FEE8785E94548845BB1857B9 /* MessageBuilder.h in Headers */,
-				7B222445F766286395C8C341 /* MutableExtensionRegistry.h in Headers */,
-				B82678C1921C2BA1FF24FD7D /* MutableField.h in Headers */,
-				25E27AC84E658489E3E544CF /* NSArray+SnapchatKit.h in Headers */,
-				C0990C4C3544E86079AF338F /* NSData+SnapchatKit.h in Headers */,
-				2D0A8DC1B8D91599941BF9D5 /* NSDictionary+SnapchatKit.h in Headers */,
-				201F619DB350D8E0E6A26519 /* NSString+SnapchatKit.h in Headers */,
-				CDE96097F3636F13D6B1236D /* ObjectivecDescriptor.pb.h in Headers */,
-				6AEB75DB255B4DF7F68AE676 /* PBArray.h in Headers */,
-				F82963F146F475AC1334F464 /* Pods-SnapchatKit_Tests-SnapchatKit-umbrella.h in Headers */,
-				26B312C47B6AEDCD92C66328 /* ProtocolBuffers.h in Headers */,
-				21B5C4BFE4DEB877BA691ECE /* RingBuffer.h in Headers */,
-				D41FE1FB0E63031E16E8F3D4 /* SKAddedFriend.h in Headers */,
-				638BCA064214B5E2AC40EB82 /* SKBlob.h in Headers */,
-				3ACE1C6E65F9E1EE2400ADA2 /* SKCashTransaction.h in Headers */,
-				2A37F33512217C3FFE1A7E5B /* SKClient+Account.h in Headers */,
-				AB86CF09AFD6CF6CE3E56C76 /* SKClient+Chat.h in Headers */,
-				DF67DACEA7B0F8A2FB599CBE /* SKClient+Device.h in Headers */,
-				2CF97C8E17DB0D3EAA52A837 /* SKClient+Discover.h in Headers */,
-				9EABA487066E7FC9A9E75992 /* SKClient+Friends.h in Headers */,
-				5268AF77C2E16BC562DDCBF7 /* SKClient+Snaps.h in Headers */,
-				0FC2A55B7B4F53C7E234CEAD /* SKClient+Stories.h in Headers */,
-				32D0B7375CA3A39551088E4E /* SKClient.h in Headers */,
-				681A3DD19662F0E438CD6B02 /* SKConversation.h in Headers */,
-				81C9593A578A9A1D8F757C43 /* SKFilter.h in Headers */,
-				67A6F9BDF98BC4FCEA9AA9C6 /* SKFoundFriend.h in Headers */,
-				7526B412A582D3D940F7E4F2 /* SKLocation.h in Headers */,
-				F20155CA3D188FB7706A9214 /* SKMessage.h in Headers */,
-				6A9D067C56CFA0118840C63C /* SKNearbyUser.h in Headers */,
-				D94D9CB8C306C01F459791E0 /* SKNewConversation.h in Headers */,
-				2C45FD09CE17617116B38B51 /* SKRequest.h in Headers */,
-				341B108E22DBB2BAEC477BDB /* SKSession.h in Headers */,
-				5A7B293C4D887F512E40BB28 /* SKSharedStoryDescription.h in Headers */,
-				14C746FCBFB13DE7BED2CFD1 /* SKSimpleUser.h in Headers */,
-				DEF1B4D594D9C66529840A0B /* SKSnap.h in Headers */,
-				C72B883DF942D09141559E17 /* SKSnapOptions.h in Headers */,
-				2D3458EE143931D9043E8D34 /* SKSnapResponse.h in Headers */,
-				7671D7F5146DD4E6EBD5AF5D /* SKStory.h in Headers */,
-				B3D44EB4CB0D39F511110084 /* SKStoryCollection.h in Headers */,
-				B94B6BC9B81410655B4C45FB /* SKStoryNote.h in Headers */,
-				E6384DF4C106A1EFE5936AD4 /* SKStoryOptions.h in Headers */,
-				471606E4FD2D8C41AAF4C29D /* SKStoryUpdater.h in Headers */,
-				CB09833EAA71D804C66952B6 /* SKThing.h in Headers */,
-				F284CF71A009BE358DC2AC64 /* SKUser.h in Headers */,
-				4B7BBA9F1667A9574DD6718F /* SKUserStory.h in Headers */,
-				2AB080BD99FDBE080BED2313 /* SSZipArchive.h in Headers */,
-				BEDD54DDF41F99E89B95CE9B /* SnapchatKit-Constants.h in Headers */,
-				246FD8ECEC071DB6BDE05A2E /* SnapchatKit.h in Headers */,
-				D827F8103B4BC91B0C76C384 /* TextFormat.h in Headers */,
-				232BB9949D014806CE6A1FF2 /* UnknownFieldSet.h in Headers */,
-				F1B3BC44F6A58033263EA0B9 /* UnknownFieldSetBuilder.h in Headers */,
-				02EE112E0E467E8DF3DF9791 /* Utilities.h in Headers */,
-				2BB26D0DBAB381AF0BA3C7CE /* WireFormat.h in Headers */,
-				2CA233C22E3403EE6D35E894 /* crypt.h in Headers */,
-				D338030AB92FEFCA24D0DE4E /* ioapi.h in Headers */,
-				4DEFF07D030E467E4EBD032B /* mztools.h in Headers */,
-				E063E5BA606B34EA33ED8501 /* unzip.h in Headers */,
-				B15765DC67F3D1270E293A8E /* zip.h in Headers */,
+				023388DFA5754C45B0A6A5C0F26D3077 /* Pods-SnapchatKit-OSX-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FA87F639920D031314E8F45C /* Headers */ = {
+		F0A610E8FE6AC783E59F67E4D2EC4964 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B50A774F10B0F92F1696E576 /* EXTKeyPathCoding.h in Headers */,
-				54CDEC3BC81A87929AFCBB13 /* EXTRuntimeExtensions.h in Headers */,
-				6E2BACB518B4B5A3CB6B12D5 /* EXTScope.h in Headers */,
-				B25A91900E2A68356DB93263 /* MTLJSONAdapter.h in Headers */,
-				2A75997295BAB555CD2CB3C4 /* MTLModel+NSCoding.h in Headers */,
-				33DE13ABA5BB06C7DC73BD88 /* MTLModel.h in Headers */,
-				5606FD756288DFDA95C11EFC /* MTLReflection.h in Headers */,
-				F438C6281FC9950B3070CD4F /* MTLTransformerErrorHandling.h in Headers */,
-				24AC952DB486CBA15DF70A7B /* MTLValueTransformer.h in Headers */,
-				585F21583D81D9D150F9AC42 /* Mantle.h in Headers */,
-				A04BD24C2E0D3887BBDB74F3 /* NSArray+MTLManipulationAdditions.h in Headers */,
-				D8F2DB01E000B4B44A7DF663 /* NSDictionary+MTLJSONKeyPath.h in Headers */,
-				D66CE564C0C570BD16CF4C43 /* NSDictionary+MTLManipulationAdditions.h in Headers */,
-				05B79CCD118252452F844B53 /* NSDictionary+MTLMappingAdditions.h in Headers */,
-				F93144363F17E0D9D34D4F87 /* NSError+MTLModelException.h in Headers */,
-				CC1368C25F6D4FF233355A99 /* NSObject+MTLComparisonAdditions.h in Headers */,
-				08A4B40F522CD26BC5C0F844 /* NSValueTransformer+MTLInversionAdditions.h in Headers */,
-				0458D6DE15DAF5364E32A021 /* NSValueTransformer+MTLPredefinedTransformerAdditions.h in Headers */,
-				42F5C0E40F2E2AA61CA25943 /* Pods-SnapchatKit_Tests-Mantle-umbrella.h in Headers */,
-				5FBBA230C00348169F58CCBE /* metamacros.h in Headers */,
+				A0AC30763233BA7BD6A9412109AB62DB /* EXTKeyPathCoding.h in Headers */,
+				DC2BD42E5AE0E113899FE3A995FB94B9 /* EXTRuntimeExtensions.h in Headers */,
+				9EB5F8A60C6EDC5104106616834E96BC /* EXTScope.h in Headers */,
+				D4D4A182342E38D86F482C196CE6B342 /* Mantle.h in Headers */,
+				E0101E016B646965B82683EE89D7A669 /* metamacros.h in Headers */,
+				8DB774211405DA6D9DC3AC9B4BF3AB59 /* MTLJSONAdapter.h in Headers */,
+				6D1C5179324E2197B925BE33548A8E0B /* MTLModel+NSCoding.h in Headers */,
+				D23DDBDFBAE8C4C9A5716B13D3FAA378 /* MTLModel.h in Headers */,
+				3A78EF3DCDA40F259FFC98CAFC79D2ED /* MTLReflection.h in Headers */,
+				3A6FC738621BE4B504C4A4FF9CECDF37 /* MTLTransformerErrorHandling.h in Headers */,
+				CDDDA9F0CAA7C9B3D08CFBD9B9ABCDB4 /* MTLValueTransformer.h in Headers */,
+				A004779939817C1A50DB833B43277E8F /* NSArray+MTLManipulationAdditions.h in Headers */,
+				D5593FE4E5038E58BA2EAA7B13FB38A8 /* NSDictionary+MTLJSONKeyPath.h in Headers */,
+				2E38B3A0594877C7393F558A96FF21EE /* NSDictionary+MTLManipulationAdditions.h in Headers */,
+				3FEC5DD2C9E80A768FA80341297A41EE /* NSDictionary+MTLMappingAdditions.h in Headers */,
+				50915B525DD3E78E926D1A1AC5F72B09 /* NSError+MTLModelException.h in Headers */,
+				8745E60DE9438702B88C9FA9D8DA0DCC /* NSObject+MTLComparisonAdditions.h in Headers */,
+				735EC43FFF3F2E70EFAB009963F395E0 /* NSValueTransformer+MTLInversionAdditions.h in Headers */,
+				9132D10211BE3A8EF9BD2A643A5980D6 /* NSValueTransformer+MTLPredefinedTransformerAdditions.h in Headers */,
+				9A3EBC3748D4F4F48DA2A0133A438B36 /* Pods-SnapchatKit_Example-Mantle-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		1E3B8E0EF530C81E1172FD7B /* Pods-SnapchatKit_Tests */ = {
+		18831A668A0553C0D85DC4D246371F0D /* Pods-SnapchatKit_Tests-SnapchatKit */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 24D01F056A1C16DA04FA9DAC /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit_Tests" */;
+			buildConfigurationList = 3A79B5131730AEB3E75247CDDD89B3DA /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit_Tests-SnapchatKit" */;
 			buildPhases = (
-				FC4A04E476D0230C7369D7DD /* Sources */,
-				5B5C1FA09C4DB7175CC572C9 /* Frameworks */,
-				00C08140D9A2BF92C9346A9E /* Headers */,
+				802208B84D8A5C7DF95F9D20DC7CB7EA /* Sources */,
+				D7D13D1E99FC565A58D508032461765F /* Frameworks */,
+				A1C6710EBFFB1E1509507121401D7FEA /* Headers */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				DF83CFD20DEE5B2498E0B432 /* PBXTargetDependency */,
-				71AAC86DA58B91099FDE7647 /* PBXTargetDependency */,
-			);
-			name = "Pods-SnapchatKit_Tests";
-			productName = "Pods-SnapchatKit_Tests";
-			productReference = 5BCC3D97332ACAEB112939B8 /* Pods_SnapchatKit_Tests.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		26409AAF5D1F27C007C9DE5E /* Pods-SnapchatKit-OSX-Mantle */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 5B7AC3FFAAE97C9D5F91240D /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit-OSX-Mantle" */;
-			buildPhases = (
-				51A8D95BAC88B32AA0F2A851 /* Sources */,
-				77C202995891D3CA0F5E92A3 /* Frameworks */,
-				A4637771EBC9A99C42C12545 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Pods-SnapchatKit-OSX-Mantle";
-			productName = "Pods-SnapchatKit-OSX-Mantle";
-			productReference = 1873516313DE12A18B441976 /* Mantle.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		5D594D2364F9E5EE2E88CA56 /* Pods-SnapchatKit_Example-SnapchatKit */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = FFE855DEAFDEA1F9A12629CD /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit_Example-SnapchatKit" */;
-			buildPhases = (
-				D6C0280CE6808BA35FF3A1AD /* Sources */,
-				FE7A3C950EDF8854D90116BB /* Frameworks */,
-				4045D0759AC1A327092F8C3A /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Pods-SnapchatKit_Example-SnapchatKit";
-			productName = "Pods-SnapchatKit_Example-SnapchatKit";
-			productReference = 92E7239EFF6E75EA9F6F3561 /* SnapchatKit.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		6C4C80E7E8DB9DCBD959FC21 /* Pods-SnapchatKit_Example */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 4C0BC0CCDD876D425C97D2AD /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit_Example" */;
-			buildPhases = (
-				0965BD34AA656F709C67ACDE /* Sources */,
-				393CCFAF77618A8DDD8EE00A /* Frameworks */,
-				A75D8509349614498E942A5E /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				D011C289AE4FAA21075FD8E3 /* PBXTargetDependency */,
-				FFF40A7F74F42D2D705B93F5 /* PBXTargetDependency */,
-			);
-			name = "Pods-SnapchatKit_Example";
-			productName = "Pods-SnapchatKit_Example";
-			productReference = 59D88C1F1755D563CB421C63 /* Pods_SnapchatKit_Example.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		879A906FB924617D2343F826 /* Pods-SnapchatKit_Tests-Mantle */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 908929BC15B84DFF422DF3F9 /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit_Tests-Mantle" */;
-			buildPhases = (
-				E25E6031EEBE83A165F67661 /* Sources */,
-				7A1BD9880A5895DE3581BA17 /* Frameworks */,
-				FA87F639920D031314E8F45C /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Pods-SnapchatKit_Tests-Mantle";
-			productName = "Pods-SnapchatKit_Tests-Mantle";
-			productReference = B9E73BE37CE97F84CA411252 /* Mantle.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		A31A9C7B30E247854E48DC87 /* Pods-SnapchatKit_Tests-SnapchatKit */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = C656930BB1F17FF6F9B78306 /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit_Tests-SnapchatKit" */;
-			buildPhases = (
-				BA9C597583EE8025F4AFE1EA /* Sources */,
-				FE3E06C3E1887EEFDF9294F2 /* Frameworks */,
-				EB279B52A80F029988129D19 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
+				465A7D8B694A2AB3C5020E8003672D65 /* PBXTargetDependency */,
 			);
 			name = "Pods-SnapchatKit_Tests-SnapchatKit";
 			productName = "Pods-SnapchatKit_Tests-SnapchatKit";
-			productReference = 88B84931C4029CE138B1A35A /* SnapchatKit.framework */;
+			productReference = BBFDD148F657EF9DEBA791AE4CA9E411 /* SnapchatKit.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		BD2F8829FC0286E7834B4A64 /* Pods-SnapchatKit-OSX */ = {
+		3561CFC22BEF9E4C896ED1A4653799E8 /* Pods-SnapchatKit-OSX */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 855D24F3C73AE41FDA40ADE0 /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit-OSX" */;
+			buildConfigurationList = 17B1A745436343209A42AE8E27A1B7F4 /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit-OSX" */;
 			buildPhases = (
-				33FE48D7149D3979FDF315C6 /* Sources */,
-				488F3B09FCC98D5F27D08DF4 /* Frameworks */,
-				7AB03A482E493F5AA146DFDB /* Headers */,
+				15EA12F566D40A41083A44485EC33C14 /* Sources */,
+				35D5FF0BA533231D687B47A54FD97916 /* Frameworks */,
+				DF13AD445F84263F7ABD4E07823E8371 /* Headers */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				3B7330E760595932E5F84D15 /* PBXTargetDependency */,
-				39E02BA456C32447B71C9F60 /* PBXTargetDependency */,
+				9D6C02565AE4ED368237894577C122A1 /* PBXTargetDependency */,
+				75463DAC6D7D3DC995D71E7796A49840 /* PBXTargetDependency */,
 			);
 			name = "Pods-SnapchatKit-OSX";
 			productName = "Pods-SnapchatKit-OSX";
-			productReference = F54BFB630D034BFBDD1AD679 /* Pods_SnapchatKit_OSX.framework */;
+			productReference = 9D100EF1DDFEDE0151BADD810E249EF8 /* Pods_SnapchatKit_OSX.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		CB84C8C430CE14A5E2FF477E /* Pods-SnapchatKit_Example-Mantle */ = {
+		49764DFCD9A1D4152B1A2580C4967F82 /* Pods-SnapchatKit_Tests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 2A94D02702FE9E46AFBFCD56 /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit_Example-Mantle" */;
+			buildConfigurationList = E916328114C6DA8AE450685C4B6F667B /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit_Tests" */;
 			buildPhases = (
-				9328C0778BC4EA91D9C741DC /* Sources */,
-				2ED87702250B297AD11540B2 /* Frameworks */,
-				5C90B73A4DC5486210CB5D32 /* Headers */,
+				388FB6536B58AAF2D264D4CCECDDA003 /* Sources */,
+				27A2C544AEEC64460D64252FC3008D5C /* Frameworks */,
+				D7009AC30A02C03A4652FC51C9F4337B /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D045F61BA97041A76F2E042364D90177 /* PBXTargetDependency */,
+				ADFE3262B5B8F2B0ED870A96F7963761 /* PBXTargetDependency */,
+			);
+			name = "Pods-SnapchatKit_Tests";
+			productName = "Pods-SnapchatKit_Tests";
+			productReference = D8762D8E7B4291A96A1D301857929925 /* Pods_SnapchatKit_Tests.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		6CB26C3AF4D302C46F6AC967036A696C /* Pods-SnapchatKit_Example-SnapchatKit */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C803C9F374D309829EB1D032F4E421EF /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit_Example-SnapchatKit" */;
+			buildPhases = (
+				0F93682B50071283A5091F6E2A194064 /* Sources */,
+				C1C160069678D16739769E6F774CD6E2 /* Frameworks */,
+				0EB77D5B0DB0A2C1082D9B9EBD602BF8 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CEE14917325CCA98B4FCA75E6D91B4F7 /* PBXTargetDependency */,
+			);
+			name = "Pods-SnapchatKit_Example-SnapchatKit";
+			productName = "Pods-SnapchatKit_Example-SnapchatKit";
+			productReference = BBFDD148F657EF9DEBA791AE4CA9E411 /* SnapchatKit.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		89CDA72857EF513C2576EBAF8DC1B118 /* Pods-SnapchatKit_Example-Mantle */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BA976E4281AA96A08B4D886E8071851E /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit_Example-Mantle" */;
+			buildPhases = (
+				62C809239C4C24EE26FD064BD4425C35 /* Sources */,
+				B827C6DD8793A275E99D59559CED9DA1 /* Frameworks */,
+				F0A610E8FE6AC783E59F67E4D2EC4964 /* Headers */,
 			);
 			buildRules = (
 			);
@@ -1905,423 +1857,550 @@
 			);
 			name = "Pods-SnapchatKit_Example-Mantle";
 			productName = "Pods-SnapchatKit_Example-Mantle";
-			productReference = 53233F46F0A7FEE3BAB2F5F0 /* Mantle.framework */;
+			productReference = 7C240829368A1DC3E8EE782EEAF704A0 /* Mantle.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		E18E7FFABB282ABAA8F80B98 /* Pods-SnapchatKit-OSX-SnapchatKit */ = {
+		9AA6D458AA9500633AE75B48B31578C8 /* Pods-SnapchatKit_Tests-Mantle */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 21768E8FF28EFC7C4A6F38AF /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit-OSX-SnapchatKit" */;
+			buildConfigurationList = C21ADECFF486DF21D8DEC124075E5AB8 /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit_Tests-Mantle" */;
 			buildPhases = (
-				E2691859BC6E8EAEBDC74A84 /* Sources */,
-				3BBAB5DCA822959497177775 /* Frameworks */,
-				9D1934C218752DF842BC1B23 /* Headers */,
+				34C3A729E06BCE544090FFBAF745017B /* Sources */,
+				B94198371F2F6D5FB4E765C0726204BA /* Frameworks */,
+				21852BF36A7404DC880114FD130AB269 /* Headers */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
+			name = "Pods-SnapchatKit_Tests-Mantle";
+			productName = "Pods-SnapchatKit_Tests-Mantle";
+			productReference = 7C240829368A1DC3E8EE782EEAF704A0 /* Mantle.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		C1D54FDF44B8FE5D2AFF98BECDA3BEF0 /* Pods-SnapchatKit-OSX-SnapchatKit */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C941164EFA20A57D383453D58911AF88 /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit-OSX-SnapchatKit" */;
+			buildPhases = (
+				88BBCCFC54CDF511429D4A771A8B6C30 /* Sources */,
+				E72438EE943DC85CB384D007AE7AC244 /* Frameworks */,
+				A26D1407F7CF49143A96FA34DB619794 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				0ED336A3038A55DB8E42A2DDA4FE31F2 /* PBXTargetDependency */,
+			);
 			name = "Pods-SnapchatKit-OSX-SnapchatKit";
 			productName = "Pods-SnapchatKit-OSX-SnapchatKit";
-			productReference = 0B18B08E9AA35CE5DC2A6970 /* SnapchatKit.framework */;
+			productReference = BBFDD148F657EF9DEBA791AE4CA9E411 /* SnapchatKit.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		C5F899B5BEC58C2D2C25FC3FC83F08D5 /* Pods-SnapchatKit_Example */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F5B8BA0FAB64774C83EE04CA36042ACF /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit_Example" */;
+			buildPhases = (
+				02E1C2544CCBE40CDB80EF5AD07F740B /* Sources */,
+				9EDFCF6799EB2B83ED09175E674A8E50 /* Frameworks */,
+				6DD736F2F6D42D1A7ED1CC48403A5BB4 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				6EA6786F8788A4BE249530DB634653DF /* PBXTargetDependency */,
+				9648134ABBDD61FA9A4CD38CFC4DF723 /* PBXTargetDependency */,
+			);
+			name = "Pods-SnapchatKit_Example";
+			productName = "Pods-SnapchatKit_Example";
+			productReference = 85DFBBC54289776922F83BCBCC6532F7 /* Pods_SnapchatKit_Example.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		CFBBDE16B24F23D7D06648FFAAF08EA0 /* Pods-SnapchatKit-OSX-Mantle */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A9776450D6BFEEC49616CC8408403A7F /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit-OSX-Mantle" */;
+			buildPhases = (
+				BBFF1645C86B72BB9A1FB58421417BD5 /* Sources */,
+				E72F781885FCF473502480C447E73CD8 /* Frameworks */,
+				1F4BCC2B349ED5D0DE2AE6F92083E3F8 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Pods-SnapchatKit-OSX-Mantle";
+			productName = "Pods-SnapchatKit-OSX-Mantle";
+			productReference = 7C240829368A1DC3E8EE782EEAF704A0 /* Mantle.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		014DB266874CFCE9C5BCEB5E /* Project object */ = {
+		D41D8CD98F00B204E9800998ECF8427E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0640;
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
 			};
-			buildConfigurationList = 3F46C6AA8A08AA0B1A1F6A41 /* Build configuration list for PBXProject "Pods" */;
+			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 			);
-			mainGroup = 9462076815C7C24A7BC15EF0;
-			productRefGroup = 4A9582C0D8D5A2E89AB5B30E /* Products */;
+			mainGroup = 7DB346D0F39D3F0E887471402A8071AB;
+			productRefGroup = EB3F31200506B4EC0BAB38AC0E45DC53 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				BD2F8829FC0286E7834B4A64 /* Pods-SnapchatKit-OSX */,
-				26409AAF5D1F27C007C9DE5E /* Pods-SnapchatKit-OSX-Mantle */,
-				E18E7FFABB282ABAA8F80B98 /* Pods-SnapchatKit-OSX-SnapchatKit */,
-				6C4C80E7E8DB9DCBD959FC21 /* Pods-SnapchatKit_Example */,
-				CB84C8C430CE14A5E2FF477E /* Pods-SnapchatKit_Example-Mantle */,
-				5D594D2364F9E5EE2E88CA56 /* Pods-SnapchatKit_Example-SnapchatKit */,
-				1E3B8E0EF530C81E1172FD7B /* Pods-SnapchatKit_Tests */,
-				879A906FB924617D2343F826 /* Pods-SnapchatKit_Tests-Mantle */,
-				A31A9C7B30E247854E48DC87 /* Pods-SnapchatKit_Tests-SnapchatKit */,
+				3561CFC22BEF9E4C896ED1A4653799E8 /* Pods-SnapchatKit-OSX */,
+				CFBBDE16B24F23D7D06648FFAAF08EA0 /* Pods-SnapchatKit-OSX-Mantle */,
+				C1D54FDF44B8FE5D2AFF98BECDA3BEF0 /* Pods-SnapchatKit-OSX-SnapchatKit */,
+				C5F899B5BEC58C2D2C25FC3FC83F08D5 /* Pods-SnapchatKit_Example */,
+				89CDA72857EF513C2576EBAF8DC1B118 /* Pods-SnapchatKit_Example-Mantle */,
+				6CB26C3AF4D302C46F6AC967036A696C /* Pods-SnapchatKit_Example-SnapchatKit */,
+				49764DFCD9A1D4152B1A2580C4967F82 /* Pods-SnapchatKit_Tests */,
+				9AA6D458AA9500633AE75B48B31578C8 /* Pods-SnapchatKit_Tests-Mantle */,
+				18831A668A0553C0D85DC4D246371F0D /* Pods-SnapchatKit_Tests-SnapchatKit */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
-		0965BD34AA656F709C67ACDE /* Sources */ = {
+		02E1C2544CCBE40CDB80EF5AD07F740B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				93DBEC6F8771645542396EDE /* Pods-SnapchatKit_Example-dummy.m in Sources */,
+				2264E1B7537847FB1E24B6EEE74ED9E3 /* Pods-SnapchatKit_Example-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		33FE48D7149D3979FDF315C6 /* Sources */ = {
+		0F93682B50071283A5091F6E2A194064 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				322438144786F9D0B1136756 /* Pods-SnapchatKit-OSX-dummy.m in Sources */,
+				B12B5D15D4404721BDC3696C7A629AF5 /* AbstractMessage.m in Sources */,
+				5AA3C1936A3820D8E9BC1D8FE05DE37A /* AbstractMessageBuilder.m in Sources */,
+				AF603D752936B17358AB6FF4246D6C09 /* Attestation.pb.m in Sources */,
+				D0E98E6916C59A771CE7C86D511FD055 /* CodedInputStream.m in Sources */,
+				C90B67B4290DEEA44470BF1577F4C8C6 /* CodedOutputStream.m in Sources */,
+				3B2953BAC27BEA23E001EA38A96EDD85 /* ConcreteExtensionField.m in Sources */,
+				65B5A153711F61BF0D37FC0DD0C36E07 /* Descriptor.pb.m in Sources */,
+				7745049219133452DDF043F1335EE362 /* ExtendableMessage.m in Sources */,
+				63912A16DF657113B7EDADE0FC3FA65B /* ExtendableMessageBuilder.m in Sources */,
+				FA90C81955AD3BA889C557BAC4F47299 /* ExtensionRegistry.m in Sources */,
+				7BE6E040D3F1AC607295260C3C909DE4 /* Field.m in Sources */,
+				08EB02EB1A0D64F62DF4EFEAC197AE50 /* GeneratedMessage.m in Sources */,
+				1ED98A92A15D6CFBACA73E27FA44A2EF /* GeneratedMessageBuilder.m in Sources */,
+				DBF2B12D278ADD15E6581A1A761B8DC4 /* ioapi.c in Sources */,
+				556B00BE2A14A7581F617394609E7F06 /* MutableExtensionRegistry.m in Sources */,
+				AEF4C40AF3FDE0931244614A70AC9910 /* MutableField.m in Sources */,
+				7D4EE1042363324DF6F26740E061D54E /* mztools.c in Sources */,
+				4964637AC990C2E5B62511EA4E609D4D /* NSArray+SnapchatKit.m in Sources */,
+				4D70F3802FFF174C2CD5354237570CB6 /* NSData+SnapchatKit.m in Sources */,
+				987A092009A08734CCB6CD47990EB207 /* NSDictionary+SnapchatKit.m in Sources */,
+				E05AECFEBB7267D2C971F2A83797EE85 /* NSString+SnapchatKit.m in Sources */,
+				686FF1CB34E4F0795A39A5D74E18077E /* ObjectivecDescriptor.pb.m in Sources */,
+				9F2BD5B80A442D5B2FBAF70AD5451E2C /* PBArray.m in Sources */,
+				FEDC22E4B5A3BF58B772CEA1463515FB /* Pods-SnapchatKit_Example-SnapchatKit-dummy.m in Sources */,
+				BE331BBE584C5DDA5061F18B0DBD43F7 /* RingBuffer.m in Sources */,
+				893F938ED76EE7673A7A0F6C17CD0F70 /* SKAddedFriend.m in Sources */,
+				5BF56770C12DFAE89B57DA8727C62793 /* SKBlob.m in Sources */,
+				C5162F5ED425FB21237997AE5CC4898A /* SKCashTransaction.m in Sources */,
+				042DA1E4404BBD3A35D5275D4A29413A /* SKClient+Account.m in Sources */,
+				A0DF13C7AD7438F4375B93128DB21EF1 /* SKClient+Chat.m in Sources */,
+				B300232873C207599BBB51BE2CDA97B6 /* SKClient+Device.m in Sources */,
+				FED1C4AF2195F2A79F78E6A21E51C79B /* SKClient+Discover.m in Sources */,
+				D6828D52214A4BA1D10A0C97A6E7E496 /* SKClient+Friends.m in Sources */,
+				2A4815BAB2A6E3324A82C79821FC20FA /* SKClient+Snaps.m in Sources */,
+				FB1535FDD51C777D055BEAD988F01B7F /* SKClient+Stories.m in Sources */,
+				E6999BDF965B57D4A038B9CFFD76FA89 /* SKClient.m in Sources */,
+				1C3E25E616DC7ACDA6A71318B5B97A0B /* SKConversation.m in Sources */,
+				BFEF6C043A14EAA70813835B40CD4868 /* SKFilter.m in Sources */,
+				242F7528027487EBDCAB8DB71CDBB224 /* SKFoundFriend.m in Sources */,
+				D45B5067BF9C0F537E9B7B065E2260D0 /* SKLocation.m in Sources */,
+				3478C6911235F8AD6BA9C548001FF475 /* SKMessage.m in Sources */,
+				9C9F0AE0C0F996C55440D182852763D9 /* SKNearbyUser.m in Sources */,
+				575DF65CEF9F1034EA84C3BCFB460C25 /* SKNewConversation.m in Sources */,
+				2505947A59E09D87EC189986798356C0 /* SKRequest.m in Sources */,
+				10D87EDBD6A461EF900178ACA1418051 /* SKSession.m in Sources */,
+				65FC258BEA145736F4CB9C917DCC5DFC /* SKSharedStoryDescription.m in Sources */,
+				4EC0C4AB25A9E263DDD76006DC34FE1A /* SKSimpleUser.m in Sources */,
+				93279811007137D5DAE3A3060A7970D7 /* SKSnap.m in Sources */,
+				7D375F95240E56B49AB9246BEBBAAF0A /* SKSnapOptions.m in Sources */,
+				9D0155280BABA02C5A7095272881FC01 /* SKSnapResponse.m in Sources */,
+				377B4976BE7CFD109B545F252618C439 /* SKStory.m in Sources */,
+				21FA76F5E9B6056E3125903D3DD6C607 /* SKStoryCollection.m in Sources */,
+				B3AD53F71382D3CCDFFBF55DFAA15121 /* SKStoryNote.m in Sources */,
+				1FB6E89D3C3C052571A2F83067A66C7F /* SKStoryOptions.m in Sources */,
+				2B239733EFEB61D079A67020119FCFAD /* SKStoryUpdater.m in Sources */,
+				CA6E5BA7CA966310534FE4C22A0950F9 /* SKThing.m in Sources */,
+				AA0BD7F44E7BEB9A8E6D5B83E7CBA2C0 /* SKUser.m in Sources */,
+				9BD5C2540AB3E6938E65AF75410E336F /* SKUserStory.m in Sources */,
+				C65F16F13CE8CEA0269420C9419982A2 /* SnapchatKit-Constants.m in Sources */,
+				9BDF151726D1BE8BA801562B4E9742E1 /* SSZipArchive.m in Sources */,
+				82230F3D2FDC4B015A8164933ABE29EC /* TextFormat.m in Sources */,
+				C173C3B5DACE68FF25CAF5642887DD2E /* UnknownFieldSet.m in Sources */,
+				2F2DBCB99EFB00EC2A9965B8FBB8E91A /* UnknownFieldSetBuilder.m in Sources */,
+				7AF32F69DFF9CD3A4BDBB7538E278E17 /* unzip.c in Sources */,
+				1A5975CE8C5E0498D886DEB4452CEEFD /* Utilities.m in Sources */,
+				4895A72C93179952912E89C31138CEE7 /* WireFormat.m in Sources */,
+				D7011E098D94BD44843CF413BE1E8DCB /* zip.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		51A8D95BAC88B32AA0F2A851 /* Sources */ = {
+		15EA12F566D40A41083A44485EC33C14 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6A304AE2999F736F8CB71C13 /* EXTRuntimeExtensions.m in Sources */,
-				670BA54D9EEC3A0F861E92D1 /* EXTScope.m in Sources */,
-				05750A109F18B9D4BE023394 /* MTLJSONAdapter.m in Sources */,
-				310C530E828EDCACBAA01DD1 /* MTLModel+NSCoding.m in Sources */,
-				92F6966CBEFD4BC08913916A /* MTLModel.m in Sources */,
-				6857116CB2C09268AF4038CE /* MTLReflection.m in Sources */,
-				2E6B51F40F8277E9FB5ED8C1 /* MTLTransformerErrorHandling.m in Sources */,
-				FD6098DCD84B7C253763DA2A /* MTLValueTransformer.m in Sources */,
-				9E8D11CFD584508E14B5A79D /* NSArray+MTLManipulationAdditions.m in Sources */,
-				87D3F8EF8EAF95C434206292 /* NSDictionary+MTLJSONKeyPath.m in Sources */,
-				09EB6F305CEC6C8B45BE8127 /* NSDictionary+MTLManipulationAdditions.m in Sources */,
-				440E6F2CBA776F99583AC306 /* NSDictionary+MTLMappingAdditions.m in Sources */,
-				997BF0B5D6FFD67A5F64A174 /* NSError+MTLModelException.m in Sources */,
-				FD09A9CF8DA29EECDE10A78A /* NSObject+MTLComparisonAdditions.m in Sources */,
-				840A18B6ADD004B75B454D56 /* NSValueTransformer+MTLInversionAdditions.m in Sources */,
-				CC33DDDA32C3B6D356876969 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */,
-				0E4D5D23AF5E9CAF2EC702DD /* Pods-SnapchatKit-OSX-Mantle-dummy.m in Sources */,
+				956A6E6A412D2CBEE8799C1F4CCFC07F /* Pods-SnapchatKit-OSX-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		9328C0778BC4EA91D9C741DC /* Sources */ = {
+		34C3A729E06BCE544090FFBAF745017B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9820D90B6652840197F5547E /* EXTRuntimeExtensions.m in Sources */,
-				218054F9F32F7A64D36ED36C /* EXTScope.m in Sources */,
-				110E1194B010D41AF45D294A /* MTLJSONAdapter.m in Sources */,
-				D71DCDE64214FDF0C4F6C386 /* MTLModel+NSCoding.m in Sources */,
-				804328A51D200ED84D97E70A /* MTLModel.m in Sources */,
-				8D92B657B7C2FB299693265D /* MTLReflection.m in Sources */,
-				B00EF504907172878DF661E0 /* MTLTransformerErrorHandling.m in Sources */,
-				3789A77349BB65922E5A1AAB /* MTLValueTransformer.m in Sources */,
-				86E7E149F294F2A0E0D8E6ED /* NSArray+MTLManipulationAdditions.m in Sources */,
-				93295C2A46E89261B0A859A5 /* NSDictionary+MTLJSONKeyPath.m in Sources */,
-				16F5989EEE19D8B976BCD2D4 /* NSDictionary+MTLManipulationAdditions.m in Sources */,
-				B6116BF0443C7AA69573228C /* NSDictionary+MTLMappingAdditions.m in Sources */,
-				6290EDFFD99F77DD4AD24A77 /* NSError+MTLModelException.m in Sources */,
-				152AABCD098E7C2CF54A5E52 /* NSObject+MTLComparisonAdditions.m in Sources */,
-				8B993B6448D2B6AA750D833B /* NSValueTransformer+MTLInversionAdditions.m in Sources */,
-				C124B95AFA41E5784D5BA178 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */,
-				403DD822CB5BE84002AB3697 /* Pods-SnapchatKit_Example-Mantle-dummy.m in Sources */,
+				1B076DF3B4692E545CA4410C3A0B9E70 /* EXTRuntimeExtensions.m in Sources */,
+				BD4E59EDF409CBFD9D9728ACF6AA5881 /* EXTScope.m in Sources */,
+				6BA8B54DDCA21FFF73BD889120B17A56 /* MTLJSONAdapter.m in Sources */,
+				46204E30E187CD54D9E99E2FAA750AE0 /* MTLModel+NSCoding.m in Sources */,
+				6FC9297284E6B97475C34E5F64955D1B /* MTLModel.m in Sources */,
+				FF789B5916DAE6C0D30932C9F259E3B8 /* MTLReflection.m in Sources */,
+				49F1F759E3211F99AE1EB258A0539A3E /* MTLTransformerErrorHandling.m in Sources */,
+				D209D6CC69F6B7EBEDBB9B94FC2B1553 /* MTLValueTransformer.m in Sources */,
+				6CD5886E1C8F03E20962E8E3CBFFFD46 /* NSArray+MTLManipulationAdditions.m in Sources */,
+				CE05F613D4B6C6F6F13C5237ED8DD23F /* NSDictionary+MTLJSONKeyPath.m in Sources */,
+				8658349B9E14201EDFD7D4697801AB42 /* NSDictionary+MTLManipulationAdditions.m in Sources */,
+				7CDB177F22682CBFA481206CADF09D37 /* NSDictionary+MTLMappingAdditions.m in Sources */,
+				79A99170C7433CE688B43AC977697B2C /* NSError+MTLModelException.m in Sources */,
+				F6C050F56A15ED6FCE70398A104B445D /* NSObject+MTLComparisonAdditions.m in Sources */,
+				23909EA74D814415AD25CAA0D3429E8A /* NSValueTransformer+MTLInversionAdditions.m in Sources */,
+				9A99F08C293A16C31870858C276DFD94 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */,
+				A6CD5AF026F0476BFA019BA291B70CA1 /* Pods-SnapchatKit_Tests-Mantle-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		BA9C597583EE8025F4AFE1EA /* Sources */ = {
+		388FB6536B58AAF2D264D4CCECDDA003 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3501CBCB3A0DF45E357D9D50 /* AbstractMessage.m in Sources */,
-				08D982B6DEE9D8A8DD91A605 /* AbstractMessageBuilder.m in Sources */,
-				8BE2EBBE2CE3CD118E52E6B6 /* Attestation.pb.m in Sources */,
-				42A1E33E81B72588A8D75E30 /* CodedInputStream.m in Sources */,
-				59BD70D83CBEECADBBF3805D /* CodedOutputStream.m in Sources */,
-				1855834EC91DA3FD0D59657F /* ConcreteExtensionField.m in Sources */,
-				9C06EAC9C04252DD0D6081BF /* Descriptor.pb.m in Sources */,
-				C61A080E1DE7872975B4EECF /* ExtendableMessage.m in Sources */,
-				6E4C2B3721D3A314F9D6F291 /* ExtendableMessageBuilder.m in Sources */,
-				B4ECE8867AE762DEF1B1E5BE /* ExtensionRegistry.m in Sources */,
-				6880312805F61A669E5BA40F /* Field.m in Sources */,
-				CC4153A0C7A6823D96718C4C /* GeneratedMessage.m in Sources */,
-				319FFF488A52A043E6F9A50C /* GeneratedMessageBuilder.m in Sources */,
-				5D8C1DDA41E3CA90029702BF /* MutableExtensionRegistry.m in Sources */,
-				4AABECA1DD2F52EB775C78B1 /* MutableField.m in Sources */,
-				100B3EF160D7A5552DAB0784 /* NSArray+SnapchatKit.m in Sources */,
-				6F0B2284146B9BD538202D12 /* NSData+SnapchatKit.m in Sources */,
-				91F29EA14084608557703C9A /* NSDictionary+SnapchatKit.m in Sources */,
-				CD8B85221903AFD0E12CB805 /* NSString+SnapchatKit.m in Sources */,
-				4C905F9F681ACA5EB62F1365 /* ObjectivecDescriptor.pb.m in Sources */,
-				B0C2E8C14CD27BA805553C1C /* PBArray.m in Sources */,
-				B05C435EC718849BA6B8B6B2 /* Pods-SnapchatKit_Tests-SnapchatKit-dummy.m in Sources */,
-				F0BCCFEA8CAA76F12057FB46 /* RingBuffer.m in Sources */,
-				FD3CCDA4F20913CEDB7D6AAA /* SKAddedFriend.m in Sources */,
-				EBC6272FBBFCF159E263B580 /* SKBlob.m in Sources */,
-				8252E835FA73E096BAFAB160 /* SKCashTransaction.m in Sources */,
-				82AD8A369B282249F17A3093 /* SKClient+Account.m in Sources */,
-				C9A3475A3982D12122BDCAD7 /* SKClient+Chat.m in Sources */,
-				CBFF88392C49F2537FCB39E3 /* SKClient+Device.m in Sources */,
-				CCABC287BF8DF4B9606BCA64 /* SKClient+Discover.m in Sources */,
-				EC9210B13B79A8C30E5C9A67 /* SKClient+Friends.m in Sources */,
-				27EB1C393CAD9F67B16FE188 /* SKClient+Snaps.m in Sources */,
-				5B3C2B89740DD789627ADB84 /* SKClient+Stories.m in Sources */,
-				8B96E3DB2C7350B9B86643DB /* SKClient.m in Sources */,
-				0E673034C1E0945C60D674D9 /* SKConversation.m in Sources */,
-				A9D3B6EC1E50EBCF7F1F1D65 /* SKFilter.m in Sources */,
-				27192CE744756B9B2A0F2CC5 /* SKFoundFriend.m in Sources */,
-				FE891402D98C4DB033CA60C4 /* SKLocation.m in Sources */,
-				1CCB2AD4ADCA9CCD36AED267 /* SKMessage.m in Sources */,
-				CE3F421B122257ECCBC8D585 /* SKNearbyUser.m in Sources */,
-				FD6590AD4CC25A7D2734A10D /* SKNewConversation.m in Sources */,
-				7F371105CBC54F6F299D3004 /* SKRequest.m in Sources */,
-				628CFEBAEC6DD114FC023FD0 /* SKSession.m in Sources */,
-				B810C1D1A95D49514E619D05 /* SKSharedStoryDescription.m in Sources */,
-				1011AB44146881FD98818A56 /* SKSimpleUser.m in Sources */,
-				7A5BF8BC10692D2E04DF6C09 /* SKSnap.m in Sources */,
-				DF268188FECF5560184BCD34 /* SKSnapOptions.m in Sources */,
-				7E49A8205F13F85517E48379 /* SKSnapResponse.m in Sources */,
-				C9380CC96C046AF00F72DB1C /* SKStory.m in Sources */,
-				D5550310E4A272DF4108A3A6 /* SKStoryCollection.m in Sources */,
-				FAC9E343FAA7307CE9512A2A /* SKStoryNote.m in Sources */,
-				DB8A0E07D28EA3872B3CF9CC /* SKStoryOptions.m in Sources */,
-				9AE79C6A27C3558522A38CA2 /* SKStoryUpdater.m in Sources */,
-				2C48640BA70E63DC3DE49DDF /* SKThing.m in Sources */,
-				4EFB4BCCB7AEFFA041622493 /* SKUser.m in Sources */,
-				47BB125E9D808519F925A9A6 /* SKUserStory.m in Sources */,
-				1AFCC2894C7B42B619C7335B /* SSZipArchive.m in Sources */,
-				DC295132D38D674A691ECF9E /* SnapchatKit-Constants.m in Sources */,
-				1CA82CF9525D04A7195D475B /* TextFormat.m in Sources */,
-				5AD9EAC65D102620FFE86A19 /* UnknownFieldSet.m in Sources */,
-				8C2F856DF57CA3BB07C2CDD7 /* UnknownFieldSetBuilder.m in Sources */,
-				A1F7B0A61E32B0FA5CD46C6F /* Utilities.m in Sources */,
-				B96CA04AAE1225CF696FAA66 /* WireFormat.m in Sources */,
-				C60D49ED676F30B7845E2CA9 /* ioapi.c in Sources */,
-				EEDC8833C276A27D22CAB5B9 /* mztools.c in Sources */,
-				A372C848180F614A291B7BD6 /* unzip.c in Sources */,
-				7A0A51884FE62E3E94709D2F /* zip.c in Sources */,
+				D2F78FAE5B3A0C938FB4B80EBF1923B3 /* Pods-SnapchatKit_Tests-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D6C0280CE6808BA35FF3A1AD /* Sources */ = {
+		62C809239C4C24EE26FD064BD4425C35 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4106B74202118E3E0D6E57C5 /* AbstractMessage.m in Sources */,
-				68F3AEB506E259448F2AB64B /* AbstractMessageBuilder.m in Sources */,
-				4293B45814FE9F05BBC8A738 /* Attestation.pb.m in Sources */,
-				7FF094D15285DE4A872C5E26 /* CodedInputStream.m in Sources */,
-				EC1C0C225A13D62C9165A3E6 /* CodedOutputStream.m in Sources */,
-				D1F511EDEE113E0451ACA3C2 /* ConcreteExtensionField.m in Sources */,
-				29053A605C057F4849362B88 /* Descriptor.pb.m in Sources */,
-				E92310B6807E95A45893E613 /* ExtendableMessage.m in Sources */,
-				AED94F6A79240EEFF1BA0A2D /* ExtendableMessageBuilder.m in Sources */,
-				CDA7DE8C36BBC580A37C677E /* ExtensionRegistry.m in Sources */,
-				7583330B7DC2FA5348694610 /* Field.m in Sources */,
-				A7E34965805DA2DF39C90E8A /* GeneratedMessage.m in Sources */,
-				6180146A0E12D0F5F6725D62 /* GeneratedMessageBuilder.m in Sources */,
-				2AED1FE5BA84BE1B43A5CFAB /* MutableExtensionRegistry.m in Sources */,
-				C1F5A0ECA14A647A3D1DF994 /* MutableField.m in Sources */,
-				E9C458601CBB443502CAF765 /* NSArray+SnapchatKit.m in Sources */,
-				33C54E7319A14672DC515B77 /* NSData+SnapchatKit.m in Sources */,
-				2CA436F80E98F4B93F06DA25 /* NSDictionary+SnapchatKit.m in Sources */,
-				51FB1B59AAE95DB52FCF341D /* NSString+SnapchatKit.m in Sources */,
-				6EFB2FC259374AA1344DDADF /* ObjectivecDescriptor.pb.m in Sources */,
-				32BC4BEE03A1D47F515B3FB3 /* PBArray.m in Sources */,
-				58DD3E186257389F527CBB80 /* Pods-SnapchatKit_Example-SnapchatKit-dummy.m in Sources */,
-				50B5518E4870A1108B44AB3E /* RingBuffer.m in Sources */,
-				42B980F643FA3241F4910C0F /* SKAddedFriend.m in Sources */,
-				087F54586B12E13AA1E5F905 /* SKBlob.m in Sources */,
-				99ED3EBA5670BFB8647DE4CD /* SKCashTransaction.m in Sources */,
-				BA2E0F490A58DB25DE7187FA /* SKClient+Account.m in Sources */,
-				47D9CC31665365AD34DF8AE7 /* SKClient+Chat.m in Sources */,
-				53DF2E946BDA366FE5CE98C7 /* SKClient+Device.m in Sources */,
-				95B380800202575D7E585813 /* SKClient+Discover.m in Sources */,
-				675A0D829DF7ADEC8AD8D480 /* SKClient+Friends.m in Sources */,
-				42B6CF04AC560E93F72C0731 /* SKClient+Snaps.m in Sources */,
-				15B2F048F78324F41404B86B /* SKClient+Stories.m in Sources */,
-				27A2EC96D041834ABAD11051 /* SKClient.m in Sources */,
-				9D046D771EB1133294D03A0F /* SKConversation.m in Sources */,
-				E0B0A055F468FF77E7333648 /* SKFilter.m in Sources */,
-				7BBCC272CE768303CDA282F0 /* SKFoundFriend.m in Sources */,
-				4297713E2C1E560D876CBD9E /* SKLocation.m in Sources */,
-				EBFC6FDD5AFEDD3CD75B1B08 /* SKMessage.m in Sources */,
-				32EBBE6F5A33C2C5BB5AA27B /* SKNearbyUser.m in Sources */,
-				6E1993144F1BE026FEF00012 /* SKNewConversation.m in Sources */,
-				40EFC64A3862973D10088FA5 /* SKRequest.m in Sources */,
-				676514B614CDDC7C302A71E4 /* SKSession.m in Sources */,
-				6B58BF1919C0462B73F9D8C1 /* SKSharedStoryDescription.m in Sources */,
-				5C3C68C913BF5EC42418EB1F /* SKSimpleUser.m in Sources */,
-				B590F05A10D57282ADF6DCFD /* SKSnap.m in Sources */,
-				58CA4F8819B0DDB21CCD337B /* SKSnapOptions.m in Sources */,
-				5D692C915F9C7548390556A6 /* SKSnapResponse.m in Sources */,
-				EB9D58FAFAB393A26C6EC1D9 /* SKStory.m in Sources */,
-				6A3AFDEEBFAF907DA4ABF231 /* SKStoryCollection.m in Sources */,
-				E872E19204E513117B4B08E4 /* SKStoryNote.m in Sources */,
-				4ED0D422BE9EFE3FB27EE656 /* SKStoryOptions.m in Sources */,
-				953EF891B8DAC44FA84D91C6 /* SKStoryUpdater.m in Sources */,
-				F017F7A5D6EBC6E9C12447E2 /* SKThing.m in Sources */,
-				7B0BFD79B7BF6CD3EF44EB5B /* SKUser.m in Sources */,
-				FA2815AF7F461E02FB242681 /* SKUserStory.m in Sources */,
-				C471C201C7F4A54FFD9C9172 /* SSZipArchive.m in Sources */,
-				EA63B8F4335E98F69602E802 /* SnapchatKit-Constants.m in Sources */,
-				3A0EF056E963FD2A3B34B2D7 /* TextFormat.m in Sources */,
-				BC6C3998081CECED8BE5FB98 /* UnknownFieldSet.m in Sources */,
-				7FA2583B70C4F5D4B9E6E6D2 /* UnknownFieldSetBuilder.m in Sources */,
-				2ADF256D23028F49F768DB30 /* Utilities.m in Sources */,
-				DD6C1986C06A59F28C7C55D7 /* WireFormat.m in Sources */,
-				D2A79160613BFAA9D61691EA /* ioapi.c in Sources */,
-				7255780A10ED06ACCF0B4E64 /* mztools.c in Sources */,
-				D2E7D2147E016EE921F568F7 /* unzip.c in Sources */,
-				252744BFB664C6961DB01E2D /* zip.c in Sources */,
+				B28D218A54569D6D4E6242C19557860F /* EXTRuntimeExtensions.m in Sources */,
+				0BB90E81EBAD7A3CC465A757B8380910 /* EXTScope.m in Sources */,
+				26011E3D61F619D4A9BCEC383FEAC05D /* MTLJSONAdapter.m in Sources */,
+				516823A4FA02BBC792E37395AD1B85DB /* MTLModel+NSCoding.m in Sources */,
+				7D91CF1B01A4BE4B453227A680729D21 /* MTLModel.m in Sources */,
+				DEA5708CAC1F0A0CB8A7F6BD2F04CC7C /* MTLReflection.m in Sources */,
+				E000175AD5BB793F4139692885D2E352 /* MTLTransformerErrorHandling.m in Sources */,
+				F3306B4D0AD2368F1784A8B01FD7D161 /* MTLValueTransformer.m in Sources */,
+				500930FB6D697F545409818C0A93179B /* NSArray+MTLManipulationAdditions.m in Sources */,
+				713AE4F662C0ABD9A6AB9CCA7E789BC9 /* NSDictionary+MTLJSONKeyPath.m in Sources */,
+				3D5C7C244711B6322687777E61E19A6C /* NSDictionary+MTLManipulationAdditions.m in Sources */,
+				77EC3AD9A16F93D2A99FA7E24077B4C2 /* NSDictionary+MTLMappingAdditions.m in Sources */,
+				DEB5BA4CC6D4E8B4A618206E8081F9CD /* NSError+MTLModelException.m in Sources */,
+				DA2AB6464AEFC1DBE969E84F5836188F /* NSObject+MTLComparisonAdditions.m in Sources */,
+				82D808B2D325BA2A254E565C8F6CC555 /* NSValueTransformer+MTLInversionAdditions.m in Sources */,
+				80C63601371D20829F892DC9CA8CC421 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */,
+				BF596A9358398FD70766E2748274387F /* Pods-SnapchatKit_Example-Mantle-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E25E6031EEBE83A165F67661 /* Sources */ = {
+		802208B84D8A5C7DF95F9D20DC7CB7EA /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DDCB03B0A12A27415C9FBA78 /* EXTRuntimeExtensions.m in Sources */,
-				22A5A04035FDBFFE356DA500 /* EXTScope.m in Sources */,
-				CA446899C7BBC77646BD88E1 /* MTLJSONAdapter.m in Sources */,
-				1B4B45662A9E71621EE49246 /* MTLModel+NSCoding.m in Sources */,
-				CDA097F8DB927993EC8F3C3C /* MTLModel.m in Sources */,
-				1586153C17E4F6008A17397D /* MTLReflection.m in Sources */,
-				7EAEE9BC93527594528B47A4 /* MTLTransformerErrorHandling.m in Sources */,
-				DE190A7FE0B2EE61A90EAA2E /* MTLValueTransformer.m in Sources */,
-				ACE7050699B1F35113150D87 /* NSArray+MTLManipulationAdditions.m in Sources */,
-				DC3D4FD00673F71DDF6DEE0E /* NSDictionary+MTLJSONKeyPath.m in Sources */,
-				C45AFC61433D61E1F3000D4D /* NSDictionary+MTLManipulationAdditions.m in Sources */,
-				7544B5BD24E53FB0911CFBE2 /* NSDictionary+MTLMappingAdditions.m in Sources */,
-				C83EAA7B2AF84CA8AFEFE781 /* NSError+MTLModelException.m in Sources */,
-				79D1FB1DC62DF225E8B20813 /* NSObject+MTLComparisonAdditions.m in Sources */,
-				3E39024EF3E9E21F4D1F9B41 /* NSValueTransformer+MTLInversionAdditions.m in Sources */,
-				248C7DBA50825196E1BAAE4A /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */,
-				9BC9A54C47418873460CF88C /* Pods-SnapchatKit_Tests-Mantle-dummy.m in Sources */,
+				675B22E93193447D18446E3DE8E25257 /* AbstractMessage.m in Sources */,
+				A574C2C6D2ACECD58389B141A6F1E391 /* AbstractMessageBuilder.m in Sources */,
+				1EBB70A8E528040C3B96E6616F4ACEA2 /* Attestation.pb.m in Sources */,
+				8E02D789287764E4CDF11A66546B5030 /* CodedInputStream.m in Sources */,
+				9D42B50B048BF376F42AA52607149E0D /* CodedOutputStream.m in Sources */,
+				95E3F7B7AE361A0A5D17D7ED1FB8B8D5 /* ConcreteExtensionField.m in Sources */,
+				B7F404289D804A430D779CF68F79E750 /* Descriptor.pb.m in Sources */,
+				362581EBF1FCC3D1700D1848419B712B /* ExtendableMessage.m in Sources */,
+				92B5E1E35104C244A329C23A1E449BEC /* ExtendableMessageBuilder.m in Sources */,
+				268F4A06D7E5CF71356647535F47A0F0 /* ExtensionRegistry.m in Sources */,
+				B27523C2DE3F1E3134712528C0F750A4 /* Field.m in Sources */,
+				9F97D4F0862F7DA7326BEB67E4F2938A /* GeneratedMessage.m in Sources */,
+				997674D7B460BEF3BB195BEB8327B01E /* GeneratedMessageBuilder.m in Sources */,
+				148C3AF9412E237E62890F1304800EAB /* ioapi.c in Sources */,
+				A2936D824BBBEA30F74B6402654D0540 /* MutableExtensionRegistry.m in Sources */,
+				803F89A1C505A07F75F3306D28C3A5C7 /* MutableField.m in Sources */,
+				C36799F94CDBC5D09A98A0A547AD3509 /* mztools.c in Sources */,
+				98203E3249D625F706F6FCA2482D971F /* NSArray+SnapchatKit.m in Sources */,
+				79969FA9CFC3C2C847770EF64F44D45F /* NSData+SnapchatKit.m in Sources */,
+				98D1C7B474D58C8E202F41AABFF874F9 /* NSDictionary+SnapchatKit.m in Sources */,
+				893613DA1F6BA1A3C33ADAC7B0FE2520 /* NSString+SnapchatKit.m in Sources */,
+				D5EAFE3970AE950839C1468BFCD076C2 /* ObjectivecDescriptor.pb.m in Sources */,
+				80D3C4F20263F275FA6E5D497B2C2978 /* PBArray.m in Sources */,
+				7CEC7865664510578601198B6481E6FA /* Pods-SnapchatKit_Tests-SnapchatKit-dummy.m in Sources */,
+				305CEBA9E37E583C6CC9F26CED58F86D /* RingBuffer.m in Sources */,
+				CB0E9CFE7C2426784AF97517C83C9578 /* SKAddedFriend.m in Sources */,
+				185F49393199308807E43E7F2987BF93 /* SKBlob.m in Sources */,
+				BAED1E04C71874842555DB3B7C492E26 /* SKCashTransaction.m in Sources */,
+				DF398EF5859B9F5086C1BE51410C5700 /* SKClient+Account.m in Sources */,
+				3A756AB0B3037F170DBDF16A0B91DFFF /* SKClient+Chat.m in Sources */,
+				C5FAD05BFDDA22A0AB15ECCB8629965A /* SKClient+Device.m in Sources */,
+				94077C3B5FC298217A2A747965A4BF92 /* SKClient+Discover.m in Sources */,
+				2D46D77583FA1839F8F18AC7F2D9B69E /* SKClient+Friends.m in Sources */,
+				F7B21C00A641625866299AE0F557B18C /* SKClient+Snaps.m in Sources */,
+				CB69B27903511FCC32710C6B799A3103 /* SKClient+Stories.m in Sources */,
+				FDC9243D7DD33C135502754F1F1F286E /* SKClient.m in Sources */,
+				90890CCD9FAFA3E17B7F50715A030987 /* SKConversation.m in Sources */,
+				10A7A4024E814E076590E646FFF0598B /* SKFilter.m in Sources */,
+				4220F732A0E16D07C76BF122C5A883DF /* SKFoundFriend.m in Sources */,
+				7AEFF01882B6D07EA6C6575E714E7ECE /* SKLocation.m in Sources */,
+				4AAA0EB9ECD70B397C419509638498B7 /* SKMessage.m in Sources */,
+				D4D48852B717CB359D93200343D510F5 /* SKNearbyUser.m in Sources */,
+				DFEB980E4F4E57C5FEB401FB969406FC /* SKNewConversation.m in Sources */,
+				28DF9E35FEEF371076C9AABB943FC426 /* SKRequest.m in Sources */,
+				33D957620493F21F222B84BA21230B19 /* SKSession.m in Sources */,
+				E84B2361DBBA9E0D06A7FA057689E716 /* SKSharedStoryDescription.m in Sources */,
+				8B65A25E3DB1397009D9C6CCB10A9C1C /* SKSimpleUser.m in Sources */,
+				06C96BD41A4B7F0388545998F3943C91 /* SKSnap.m in Sources */,
+				F1D71D1C89028248B09C70E609D53ECE /* SKSnapOptions.m in Sources */,
+				31F9DB362566BA94B17E3D7ACB3D3E0C /* SKSnapResponse.m in Sources */,
+				EF806F7116EEA807CA2999CE29687C93 /* SKStory.m in Sources */,
+				CC91A48CA4DDA6014C0B2ADB8899108F /* SKStoryCollection.m in Sources */,
+				F02AD884511F86B6072F31F21E65FD92 /* SKStoryNote.m in Sources */,
+				753F635A30348BC0E506D31883DCE94F /* SKStoryOptions.m in Sources */,
+				2D7E75274682CC83AA1FDCB1BDDDB3C3 /* SKStoryUpdater.m in Sources */,
+				53C8EBF58BACE87EA90FA1EA39E6ADBD /* SKThing.m in Sources */,
+				59445FD23AD929AD67914FFB3C7520F4 /* SKUser.m in Sources */,
+				ED5C837809483B9C9AAA74610D4D4487 /* SKUserStory.m in Sources */,
+				D9AB44CFBFDCC7EDA69D5BA7A953BECD /* SnapchatKit-Constants.m in Sources */,
+				8A403109FD2BF4AACE5A2FE90CF7D916 /* SSZipArchive.m in Sources */,
+				3511A586469839753FD18D25F2674AC2 /* TextFormat.m in Sources */,
+				0120362E8FDC4F1EBE0377D52527161F /* UnknownFieldSet.m in Sources */,
+				DB1EA51D93B03B1F6996245180D5781A /* UnknownFieldSetBuilder.m in Sources */,
+				F2A1C19B2F3B275D87FCA549545ED92E /* unzip.c in Sources */,
+				FDEA050FD7978641030E57BEFE8FA338 /* Utilities.m in Sources */,
+				AAC28F6DC761DADDBCB2ED306E4807A6 /* WireFormat.m in Sources */,
+				985FB0D650981B7D97E84F1A97B4F9D5 /* zip.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E2691859BC6E8EAEBDC74A84 /* Sources */ = {
+		88BBCCFC54CDF511429D4A771A8B6C30 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BC033CBF12EF5CB38F9FDAFB /* AbstractMessage.m in Sources */,
-				8C105CDC97E22B3017AC771F /* AbstractMessageBuilder.m in Sources */,
-				BFFC774096EB83C9D41F6177 /* Attestation.pb.m in Sources */,
-				4C5DBC648CE953302700075F /* CodedInputStream.m in Sources */,
-				B966837BEE99D257E6A53925 /* CodedOutputStream.m in Sources */,
-				B7D01A61247038E49A62FF7A /* ConcreteExtensionField.m in Sources */,
-				A8CE78B0E4865C5FC4228C58 /* Descriptor.pb.m in Sources */,
-				66155514E28D8F2E4529EC37 /* ExtendableMessage.m in Sources */,
-				4D0934FCE4433948918697F7 /* ExtendableMessageBuilder.m in Sources */,
-				1A5AFE6A8B2FEE7288DEED60 /* ExtensionRegistry.m in Sources */,
-				A60E58ADA6A60B126DC7B270 /* Field.m in Sources */,
-				ACC4D3AACF9D3633F626814F /* GeneratedMessage.m in Sources */,
-				EA298192CA481198A90DE826 /* GeneratedMessageBuilder.m in Sources */,
-				252ACE2C909E7A359525294E /* MutableExtensionRegistry.m in Sources */,
-				94E186BF12C395C218B79704 /* MutableField.m in Sources */,
-				EAC4AB0A8247BE4BD7C28CE5 /* NSArray+SnapchatKit.m in Sources */,
-				2C72A82053A41B106C39D5BB /* NSData+SnapchatKit.m in Sources */,
-				BD56D7AF7AA81ED99B3D132F /* NSDictionary+SnapchatKit.m in Sources */,
-				4F39A78CF6393D0318613C25 /* NSString+SnapchatKit.m in Sources */,
-				B57DF02C279D103105DD7B77 /* ObjectivecDescriptor.pb.m in Sources */,
-				107C758D74525A4BACC126C7 /* PBArray.m in Sources */,
-				7DC1BB222E06AAFE6A3D9EE8 /* Pods-SnapchatKit-OSX-SnapchatKit-dummy.m in Sources */,
-				1239BC592573C7195BFF9EA0 /* RingBuffer.m in Sources */,
-				04EAD7E1C58FB7C291AEF825 /* SKAddedFriend.m in Sources */,
-				6FBDFDB7C5D7251A2AF79F0D /* SKBlob.m in Sources */,
-				EC7EFBA2154031EEB74007F1 /* SKCashTransaction.m in Sources */,
-				FA62F1E29E3564025BF7A97A /* SKClient+Account.m in Sources */,
-				0B7A864E3694EF1ED0FB53B0 /* SKClient+Chat.m in Sources */,
-				7DDA900B32D8FD0A92B93721 /* SKClient+Device.m in Sources */,
-				630495DC5633CA5447F7121C /* SKClient+Discover.m in Sources */,
-				517C68C58DAFA6D045161FB9 /* SKClient+Friends.m in Sources */,
-				A398246401F4C9A16D0F18E0 /* SKClient+Snaps.m in Sources */,
-				F7FE7E5B4B382494C8FF5801 /* SKClient+Stories.m in Sources */,
-				FEB5BF0A4BC14959C0C3B47A /* SKClient.m in Sources */,
-				94343B934AAECDDB1F7BC4CF /* SKConversation.m in Sources */,
-				2CB298399D44BBC00DD7D822 /* SKFilter.m in Sources */,
-				BE879F5CEFBE2DBA55CCF4CE /* SKFoundFriend.m in Sources */,
-				0ED972130FBE078D5B9CF594 /* SKLocation.m in Sources */,
-				96A2E570D3F84D721D844E47 /* SKMessage.m in Sources */,
-				09279759F91D12E069867969 /* SKNearbyUser.m in Sources */,
-				1F490674EE81DEF6CCB6EF05 /* SKNewConversation.m in Sources */,
-				5A8779F2571F131EFBB1DA4F /* SKRequest.m in Sources */,
-				3AB879ED75750BAA20844DA3 /* SKSession.m in Sources */,
-				44535CF5C1977174A22B289F /* SKSharedStoryDescription.m in Sources */,
-				A9A3CA6A0785D40DFF6C871F /* SKSimpleUser.m in Sources */,
-				BF289DFD6456CFAE6373C264 /* SKSnap.m in Sources */,
-				94200A642B2CAA9401D84B46 /* SKSnapOptions.m in Sources */,
-				0250B2604E1F7FDBAF4C8240 /* SKSnapResponse.m in Sources */,
-				65B81FB78039585AD03EE5F8 /* SKStory.m in Sources */,
-				3A891214EBE7D990E5A81DBD /* SKStoryCollection.m in Sources */,
-				E05190CB533ECBE7031C8180 /* SKStoryNote.m in Sources */,
-				F08B7331F6C611CE350E2896 /* SKStoryOptions.m in Sources */,
-				0CA87602D1EB72F9A1416C65 /* SKStoryUpdater.m in Sources */,
-				6B931A3FA0D8CF9929B52335 /* SKThing.m in Sources */,
-				D794F004ABA4395C727F6674 /* SKUser.m in Sources */,
-				7E022FCEC5F8DF32A8322A10 /* SKUserStory.m in Sources */,
-				3F1A535C076C0CABB5A672AB /* SSZipArchive.m in Sources */,
-				5AC65D12FCAA8F149C44D9AB /* SnapchatKit-Constants.m in Sources */,
-				BEBC9081A0F4D6C954308634 /* TextFormat.m in Sources */,
-				2D9D2359C9FD4C1D616365E4 /* UnknownFieldSet.m in Sources */,
-				EDB1505CE09418B3F692519B /* UnknownFieldSetBuilder.m in Sources */,
-				471D420705E3110EBC6D773D /* Utilities.m in Sources */,
-				9D06F6B5BE77890EB29C987F /* WireFormat.m in Sources */,
-				60E2CFC4AFDDF93E438833C0 /* ioapi.c in Sources */,
-				8AC2B44A34D3C1B0BCA165BB /* mztools.c in Sources */,
-				CF5059529FDC646C45103006 /* unzip.c in Sources */,
-				AC29F279D49B4D08C13A5CFE /* zip.c in Sources */,
+				8CD58B6E46D98F6B469F0D53E56F3142 /* AbstractMessage.m in Sources */,
+				80E3A5718419A00654103E2D76C40DC7 /* AbstractMessageBuilder.m in Sources */,
+				7E899B86BAFA98237D97A32B1BC055BF /* Attestation.pb.m in Sources */,
+				367747D40D02006C7203A8FE9D8B4EF1 /* CodedInputStream.m in Sources */,
+				DD262F615BA14F4CF16F59966D429D03 /* CodedOutputStream.m in Sources */,
+				FA3E11724F59F5058E629867E1167457 /* ConcreteExtensionField.m in Sources */,
+				375918802120B79CE1A811521FF565C3 /* Descriptor.pb.m in Sources */,
+				3C35A212B467A3395A6925E546D113BE /* ExtendableMessage.m in Sources */,
+				A104C68EC950DF3588B72706E85EC36A /* ExtendableMessageBuilder.m in Sources */,
+				AD2E7752B133F855C03C5F1B1D188820 /* ExtensionRegistry.m in Sources */,
+				B15127483D4E7BEB3DD36CCED6617C8C /* Field.m in Sources */,
+				F79573CC859A0680C237044ADF482B40 /* GeneratedMessage.m in Sources */,
+				8C4E7CA7C2ECD97C9848176090E0F4D6 /* GeneratedMessageBuilder.m in Sources */,
+				74EEA546A96531BDE2F22FD4495E4AEC /* ioapi.c in Sources */,
+				4C25AFBB79C3C2F852F1C3F28A9C503C /* MutableExtensionRegistry.m in Sources */,
+				3D4B72F09A7D1AF5AC53C83EB21EC908 /* MutableField.m in Sources */,
+				AF454BAAC58CB4B904C62B393C392345 /* mztools.c in Sources */,
+				6E8A9BA92639A36DBC0DE93AE0DD78F0 /* NSArray+SnapchatKit.m in Sources */,
+				83C9C8C59AE16FF7E3935AAE85550054 /* NSData+SnapchatKit.m in Sources */,
+				885794CDC9F77A421C1DB599DADEA5D6 /* NSDictionary+SnapchatKit.m in Sources */,
+				0981354675608E7EBD38A6EEBF66B37C /* NSString+SnapchatKit.m in Sources */,
+				FB5972E82F0ADA356D484C47B039EB5C /* ObjectivecDescriptor.pb.m in Sources */,
+				FB9C1587270D3BCB443EA848DAEE4C5F /* PBArray.m in Sources */,
+				7A26BB491B363D1023D7446361049660 /* Pods-SnapchatKit-OSX-SnapchatKit-dummy.m in Sources */,
+				445F6FE8D9561E076CAFD7F720282A17 /* RingBuffer.m in Sources */,
+				F3A05D289FC621F6A6C9F3E6CF1DBE8D /* SKAddedFriend.m in Sources */,
+				B0C615AECE49899C2361FDFBBD35CAB7 /* SKBlob.m in Sources */,
+				5D38AF3FABF526BFA17067B74A14097F /* SKCashTransaction.m in Sources */,
+				5F596EC498A574B734DAC74A2F5B40CB /* SKClient+Account.m in Sources */,
+				E73B87CE570187A97236785B79B51AA9 /* SKClient+Chat.m in Sources */,
+				87C8E91488B9B212F2A118EEECDB14C7 /* SKClient+Device.m in Sources */,
+				4A4D4EC9627FE511EFBA1983DCA59BBD /* SKClient+Discover.m in Sources */,
+				09C58BC21A0FBF1C5429A24448572F2C /* SKClient+Friends.m in Sources */,
+				5DB01101ED96777BD84AB8AACEB7A6BB /* SKClient+Snaps.m in Sources */,
+				9B97BEF2E3CBC1E97617A003F1B98E0A /* SKClient+Stories.m in Sources */,
+				8AB80666C594FAC7D8C987FB14637FE7 /* SKClient.m in Sources */,
+				98F3CAD0BECEB44DF487E880AC8817E2 /* SKConversation.m in Sources */,
+				C0890754A06E690B5CF7779383382159 /* SKFilter.m in Sources */,
+				3BCEE80E6BC7E6310081231A8F46E468 /* SKFoundFriend.m in Sources */,
+				DA15C7DBB4AF9459D0BF6660F61E11AD /* SKLocation.m in Sources */,
+				4C18FFE6F916886595FDDFA4893EC18D /* SKMessage.m in Sources */,
+				486F8E44328E05773A32FABF6363785A /* SKNearbyUser.m in Sources */,
+				EA421C49ED5CB42A1E100FFE23A6F128 /* SKNewConversation.m in Sources */,
+				B64D3BCF60253BC795C2B97945369172 /* SKRequest.m in Sources */,
+				B44551B05613F7C209980BA8F692E06A /* SKSession.m in Sources */,
+				019F98F946817BFC8036990FC4866029 /* SKSharedStoryDescription.m in Sources */,
+				6B2824B75691F9C3DE9D89565AD14BCB /* SKSimpleUser.m in Sources */,
+				EC6E285E97BC2568438B6ECEA648AD17 /* SKSnap.m in Sources */,
+				117837E528FF3B6B5031482C70232403 /* SKSnapOptions.m in Sources */,
+				AA19F2DC4D4C3C1D51FC12FBB40043F4 /* SKSnapResponse.m in Sources */,
+				815B3644CF9B1A17DF09B89FD4F90AD0 /* SKStory.m in Sources */,
+				45D38CB575713150B3A90D9D38ABD156 /* SKStoryCollection.m in Sources */,
+				185E6B9D1562C1D1E1A49B73FC1FF46F /* SKStoryNote.m in Sources */,
+				6CFFFE8D066AC8A212E4332495A030E4 /* SKStoryOptions.m in Sources */,
+				5A1C61619D279CD483BDD48CFFD7BAAD /* SKStoryUpdater.m in Sources */,
+				A75E694DA35CE46237D3311DDAF8E8E9 /* SKThing.m in Sources */,
+				B9FB2048F4E99A5867CC972C0CDCD527 /* SKUser.m in Sources */,
+				3FF7C22D30BB92DD66F5708F9FB17399 /* SKUserStory.m in Sources */,
+				A68C5637F3A72037EB47243C39388E5C /* SnapchatKit-Constants.m in Sources */,
+				2E159F707367B81C694A7E642EF8E9B8 /* SSZipArchive.m in Sources */,
+				2A3FD722D66554C3FD99A077BE65D6B7 /* TextFormat.m in Sources */,
+				E23D57BFB4769ABEF5C651093A1B5D64 /* UnknownFieldSet.m in Sources */,
+				5A4FCB51BD6040760589B70D51EA7F6A /* UnknownFieldSetBuilder.m in Sources */,
+				70BCAD21362565B8B6FCE6B313D64E2A /* unzip.c in Sources */,
+				46250D8FE675647F879F57FA4B5C30A9 /* Utilities.m in Sources */,
+				D6E9A980F45113FC9B921F444BAD2F58 /* WireFormat.m in Sources */,
+				333746533E88A8D63428AAB777A2EDE8 /* zip.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FC4A04E476D0230C7369D7DD /* Sources */ = {
+		BBFF1645C86B72BB9A1FB58421417BD5 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D6E30A4C3CCF449751087B80 /* Pods-SnapchatKit_Tests-dummy.m in Sources */,
+				760583C6D0293B56264F7E3A9C8703A3 /* EXTRuntimeExtensions.m in Sources */,
+				33652DC56E0E09225FB68B91D2FC9618 /* EXTScope.m in Sources */,
+				4D444B31D12FFC10F880F22B7BE29EC3 /* MTLJSONAdapter.m in Sources */,
+				479198E6D223F3F7172CE0402F5E2ED2 /* MTLModel+NSCoding.m in Sources */,
+				5F84E4E611C94A8833A393198E0C439C /* MTLModel.m in Sources */,
+				6D94E564F4ED8B08C5A4F4044813B8A7 /* MTLReflection.m in Sources */,
+				3A3C6B40096B06D7E7A863D6B449807A /* MTLTransformerErrorHandling.m in Sources */,
+				FA61B00A1EA848372BC2699F346285D3 /* MTLValueTransformer.m in Sources */,
+				CA8B1C94080A42E191AD633351906F64 /* NSArray+MTLManipulationAdditions.m in Sources */,
+				D9AE24C66EC8F86F6C6794256914021E /* NSDictionary+MTLJSONKeyPath.m in Sources */,
+				E90B162E1CC2FFCDFD08BE7A4DC3790E /* NSDictionary+MTLManipulationAdditions.m in Sources */,
+				4C9D37555F78D0BB3F541E6DF9A26639 /* NSDictionary+MTLMappingAdditions.m in Sources */,
+				0CF6E8F089E0B74DC3B3895890C8FB64 /* NSError+MTLModelException.m in Sources */,
+				8329E0046C4D88212E52F57626494008 /* NSObject+MTLComparisonAdditions.m in Sources */,
+				8C2B5C50D6D72F51C6240F7F9750A892 /* NSValueTransformer+MTLInversionAdditions.m in Sources */,
+				AE22BE5B8F66CCD2942B8D28628BC51A /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */,
+				686810271159BBFDCF6575E22E786E36 /* Pods-SnapchatKit-OSX-Mantle-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		39E02BA456C32447B71C9F60 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Pods-SnapchatKit-OSX-SnapchatKit";
-			target = E18E7FFABB282ABAA8F80B98 /* Pods-SnapchatKit-OSX-SnapchatKit */;
-			targetProxy = 4C658D40249678B7A1170C58 /* PBXContainerItemProxy */;
-		};
-		3B7330E760595932E5F84D15 /* PBXTargetDependency */ = {
+		0ED336A3038A55DB8E42A2DDA4FE31F2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-SnapchatKit-OSX-Mantle";
-			target = 26409AAF5D1F27C007C9DE5E /* Pods-SnapchatKit-OSX-Mantle */;
-			targetProxy = E6504F04604812A241536E5B /* PBXContainerItemProxy */;
+			target = CFBBDE16B24F23D7D06648FFAAF08EA0 /* Pods-SnapchatKit-OSX-Mantle */;
+			targetProxy = 66BD34445487482ABE102641D4F513E9 /* PBXContainerItemProxy */;
 		};
-		71AAC86DA58B91099FDE7647 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Pods-SnapchatKit_Tests-SnapchatKit";
-			target = A31A9C7B30E247854E48DC87 /* Pods-SnapchatKit_Tests-SnapchatKit */;
-			targetProxy = 0713F8E87E2B4B7093623855 /* PBXContainerItemProxy */;
-		};
-		D011C289AE4FAA21075FD8E3 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Pods-SnapchatKit_Example-Mantle";
-			target = CB84C8C430CE14A5E2FF477E /* Pods-SnapchatKit_Example-Mantle */;
-			targetProxy = 9769921DA48916F4420E0D7C /* PBXContainerItemProxy */;
-		};
-		DF83CFD20DEE5B2498E0B432 /* PBXTargetDependency */ = {
+		465A7D8B694A2AB3C5020E8003672D65 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-SnapchatKit_Tests-Mantle";
-			target = 879A906FB924617D2343F826 /* Pods-SnapchatKit_Tests-Mantle */;
-			targetProxy = 5C211129D944DB51A0D7A581 /* PBXContainerItemProxy */;
+			target = 9AA6D458AA9500633AE75B48B31578C8 /* Pods-SnapchatKit_Tests-Mantle */;
+			targetProxy = 5CB6A6D98D721D2ECE56382BA98DFDF7 /* PBXContainerItemProxy */;
 		};
-		FFF40A7F74F42D2D705B93F5 /* PBXTargetDependency */ = {
+		6EA6786F8788A4BE249530DB634653DF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-SnapchatKit_Example-Mantle";
+			target = 89CDA72857EF513C2576EBAF8DC1B118 /* Pods-SnapchatKit_Example-Mantle */;
+			targetProxy = 2549D57756EA86442D8DE840850956D0 /* PBXContainerItemProxy */;
+		};
+		75463DAC6D7D3DC995D71E7796A49840 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-SnapchatKit-OSX-SnapchatKit";
+			target = C1D54FDF44B8FE5D2AFF98BECDA3BEF0 /* Pods-SnapchatKit-OSX-SnapchatKit */;
+			targetProxy = 39CA70B1A1DEAF4702193C1CAD4DC9F7 /* PBXContainerItemProxy */;
+		};
+		9648134ABBDD61FA9A4CD38CFC4DF723 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-SnapchatKit_Example-SnapchatKit";
-			target = 5D594D2364F9E5EE2E88CA56 /* Pods-SnapchatKit_Example-SnapchatKit */;
-			targetProxy = 4E85A322C74630019FFE358B /* PBXContainerItemProxy */;
+			target = 6CB26C3AF4D302C46F6AC967036A696C /* Pods-SnapchatKit_Example-SnapchatKit */;
+			targetProxy = 860FED3CFA68D5F356951FC868117F94 /* PBXContainerItemProxy */;
+		};
+		9D6C02565AE4ED368237894577C122A1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-SnapchatKit-OSX-Mantle";
+			target = CFBBDE16B24F23D7D06648FFAAF08EA0 /* Pods-SnapchatKit-OSX-Mantle */;
+			targetProxy = 61690EC51D3B1E374DB1D3D0CB4E969D /* PBXContainerItemProxy */;
+		};
+		ADFE3262B5B8F2B0ED870A96F7963761 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-SnapchatKit_Tests-SnapchatKit";
+			target = 18831A668A0553C0D85DC4D246371F0D /* Pods-SnapchatKit_Tests-SnapchatKit */;
+			targetProxy = 0E3DA6C9301FC91647B763526B75D29F /* PBXContainerItemProxy */;
+		};
+		CEE14917325CCA98B4FCA75E6D91B4F7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-SnapchatKit_Example-Mantle";
+			target = 89CDA72857EF513C2576EBAF8DC1B118 /* Pods-SnapchatKit_Example-Mantle */;
+			targetProxy = D4BB82AC6978E3FB574E83918FBCDAA1 /* PBXContainerItemProxy */;
+		};
+		D045F61BA97041A76F2E042364D90177 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-SnapchatKit_Tests-Mantle";
+			target = 9AA6D458AA9500633AE75B48B31578C8 /* Pods-SnapchatKit_Tests-Mantle */;
+			targetProxy = 2755A1CC3ABAC9867A40A2257BB6FF64 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		06440C44ABBA8242EBA08A77 /* Debug */ = {
+		0211CF1FA131D0FC994324626994C3C4 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C5DE13676C268EA621449922 /* Pods-SnapchatKit_Tests-Mantle-Private.xcconfig */;
+			baseConfigurationReference = 60201A8531061616003E37FB1E3AF624 /* Pods-SnapchatKit_Tests-Mantle.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-SnapchatKit_Tests-Mantle/Pods-SnapchatKit_Tests-Mantle-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit_Tests-Mantle/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Tests-Mantle/Pods-SnapchatKit_Tests-Mantle.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = Mantle;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		0A3AE0CE063AB4D8D53086C47B50A574 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3B5C08557F4B29304AA56AEC7D400D9F /* Pods-SnapchatKit_Tests-SnapchatKit.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-SnapchatKit_Tests-SnapchatKit/Pods-SnapchatKit_Tests-SnapchatKit-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit_Tests-SnapchatKit/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Tests-SnapchatKit/Pods-SnapchatKit_Tests-SnapchatKit.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = SnapchatKit;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		25C05BCB78E0FA751ADC63FF7D310250 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 60201A8531061616003E37FB1E3AF624 /* Pods-SnapchatKit_Tests-Mantle.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
@@ -2346,9 +2425,39 @@
 			};
 			name = Debug;
 		};
-		0B9B1A5C0B2E0CAE581AFFAF /* Release */ = {
+		2AEEB902C6793BA652251F5DC6EA324E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FE9A32571C6172EF5F9B70FD /* Pods-SnapchatKit-OSX.release.xcconfig */;
+			baseConfigurationReference = B178E7B7DF86E0DBEE7A51DB140F29A3 /* Pods-SnapchatKit-OSX.debug.xcconfig */;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit-OSX/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit-OSX/Pods-SnapchatKit-OSX.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = Pods_SnapchatKit_OSX;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		485BAD33A8498D558CAE6C895C23B045 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 33BC1AF5B43B9D9D4E7129B4BC704208 /* Pods-SnapchatKit-OSX-Mantle.xcconfig */;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
@@ -2359,16 +2468,14 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_VERSION = A;
-				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit-OSX/Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-SnapchatKit-OSX-Mantle/Pods-SnapchatKit-OSX-Mantle-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit-OSX-Mantle/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
-				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit-OSX/Pods-SnapchatKit-OSX.modulemap";
+				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit-OSX-Mantle/Pods-SnapchatKit-OSX-Mantle.modulemap";
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = Pods_SnapchatKit_OSX;
+				PRODUCT_NAME = Mantle;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -2376,7 +2483,64 @@
 			};
 			name = Release;
 		};
-		146EB60A01FEB5014E9F85E5 /* Release */ = {
+		567B8A20A3F29EC90776453F36F1FB1E /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B313D16EBCED2CE282F1548F5502B190 /* Pods-SnapchatKit_Example.release.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit_Example/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Example/Pods-SnapchatKit_Example.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = Pods_SnapchatKit_Example;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		5EDBD32C39E404A44393E1D1F29485D0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 72F3609C47429493997503C14DD74194 /* Pods-SnapchatKit_Example-SnapchatKit.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-SnapchatKit_Example-SnapchatKit/Pods-SnapchatKit_Example-SnapchatKit-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit_Example-SnapchatKit/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Example-SnapchatKit/Pods-SnapchatKit_Example-SnapchatKit.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = SnapchatKit;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		70D6A3A7860D8F36291F6B722CE9F9F4 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -2411,36 +2575,9 @@
 			};
 			name = Release;
 		};
-		1AE4F3DC41496FB11B4B26C7 /* Debug */ = {
+		727BB0F812E2A5908B2BCD3187F03C42 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DFEB6906EBD2B7C0F34E76B4 /* Pods-SnapchatKit_Example-SnapchatKit-Private.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-SnapchatKit_Example-SnapchatKit/Pods-SnapchatKit_Example-SnapchatKit-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit_Example-SnapchatKit/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Example-SnapchatKit/Pods-SnapchatKit_Example-SnapchatKit.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = SnapchatKit;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		3C48E69B416754A0D93C8B78 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 90D6B47A535307DE73D6422E /* Pods-SnapchatKit_Example.release.xcconfig */;
+			baseConfigurationReference = 71A8832A82F9F7AA9EB8BFCDD2C5BEB7 /* Pods-SnapchatKit_Example.debug.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
@@ -2453,90 +2590,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Example/Pods-SnapchatKit_Example.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = Pods_SnapchatKit_Example;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		4174B021CEB7D86A5301CB0A /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = DF748A340BF9306E32B97ED3 /* Pods-SnapchatKit_Example-Mantle-Private.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-SnapchatKit_Example-Mantle/Pods-SnapchatKit_Example-Mantle-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit_Example-Mantle/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Example-Mantle/Pods-SnapchatKit_Example-Mantle.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = Mantle;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		4CEAFA43FF6C232D206B4BCE /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = A00A37246F318C66CDCFC569 /* Pods-SnapchatKit-OSX-Mantle-Private.xcconfig */;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_VERSION = A;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-SnapchatKit-OSX-Mantle/Pods-SnapchatKit-OSX-Mantle-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit-OSX-Mantle/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
-				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit-OSX-Mantle/Pods-SnapchatKit-OSX-Mantle.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = Mantle;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		4D9C52DF5FF1F6F61FC5554B /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FAA670771CDCBC81331CC379 /* Pods-SnapchatKit_Example.debug.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit_Example/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
 				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Example/Pods-SnapchatKit_Example.modulemap";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				OTHER_LDFLAGS = "";
@@ -2551,63 +2605,7 @@
 			};
 			name = Debug;
 		};
-		5B4EFEF8F877F59478A0A117 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7E9DDD2E3FB426249A82B662 /* Pods-SnapchatKit-OSX-SnapchatKit-Private.xcconfig */;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_VERSION = A;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-SnapchatKit-OSX-SnapchatKit/Pods-SnapchatKit-OSX-SnapchatKit-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit-OSX-SnapchatKit/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
-				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit-OSX-SnapchatKit/Pods-SnapchatKit-OSX-SnapchatKit.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = SnapchatKit;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		6CD95DCC8E3CC8CD7E1518F9 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 215676CE55DE6C39627F6595 /* Pods-SnapchatKit_Tests.debug.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit_Tests/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Tests/Pods-SnapchatKit_Tests.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = Pods_SnapchatKit_Tests;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		729F80CB83D7035CA985BBE0 /* Debug */ = {
+		80C632F58EE202C42BB47E91FB960338 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -2647,9 +2645,9 @@
 			};
 			name = Debug;
 		};
-		8EC9C0827163A18C642FC458 /* Release */ = {
+		837EDE2EF65FBA86E21FC93A612EE69B /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B2CC18BCB4D507891F83A273 /* Pods-SnapchatKit_Tests-SnapchatKit-Private.xcconfig */;
+			baseConfigurationReference = B93970AA91389B580BA81FA9119ABEB4 /* Pods-SnapchatKit_Example-Mantle.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
@@ -2658,14 +2656,14 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-SnapchatKit_Tests-SnapchatKit/Pods-SnapchatKit_Tests-SnapchatKit-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit_Tests-SnapchatKit/Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-SnapchatKit_Example-Mantle/Pods-SnapchatKit_Example-Mantle-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit_Example-Mantle/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Tests-SnapchatKit/Pods-SnapchatKit_Tests-SnapchatKit.modulemap";
+				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Example-Mantle/Pods-SnapchatKit_Example-Mantle.modulemap";
 				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = SnapchatKit;
+				PRODUCT_NAME = Mantle;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -2674,9 +2672,9 @@
 			};
 			name = Release;
 		};
-		96CCA19679401298913A26E7 /* Release */ = {
+		859232D9EAAF07288BE565F406937B5C /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7E9DDD2E3FB426249A82B662 /* Pods-SnapchatKit-OSX-SnapchatKit-Private.xcconfig */;
+			baseConfigurationReference = 68A1C5A3B897ADB8E2827950CE2912D7 /* Pods-SnapchatKit-OSX-SnapchatKit.xcconfig */;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
@@ -2702,9 +2700,9 @@
 			};
 			name = Release;
 		};
-		A0A0D5EBB7DDDD7616C0E9BA /* Release */ = {
+		8BC6EE817104DAB84386CB1A4BC9E7A0 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DFEB6906EBD2B7C0F34E76B4 /* Pods-SnapchatKit_Example-SnapchatKit-Private.xcconfig */;
+			baseConfigurationReference = 3B5C08557F4B29304AA56AEC7D400D9F /* Pods-SnapchatKit_Tests-SnapchatKit.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
@@ -2713,12 +2711,12 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-SnapchatKit_Example-SnapchatKit/Pods-SnapchatKit_Example-SnapchatKit-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit_Example-SnapchatKit/Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-SnapchatKit_Tests-SnapchatKit/Pods-SnapchatKit_Tests-SnapchatKit-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit_Tests-SnapchatKit/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Example-SnapchatKit/Pods-SnapchatKit_Example-SnapchatKit.modulemap";
+				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Tests-SnapchatKit/Pods-SnapchatKit_Tests-SnapchatKit.modulemap";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_NAME = SnapchatKit;
 				SDKROOT = iphoneos;
@@ -2729,36 +2727,9 @@
 			};
 			name = Release;
 		};
-		A11EF6B0853081456886D303 /* Release */ = {
+		8F968122EA983282306F3399984B5571 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C5DE13676C268EA621449922 /* Pods-SnapchatKit_Tests-Mantle-Private.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-SnapchatKit_Tests-Mantle/Pods-SnapchatKit_Tests-Mantle-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit_Tests-Mantle/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Tests-Mantle/Pods-SnapchatKit_Tests-Mantle.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = Mantle;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		AE1914EAFDF41DA631EBB31E /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = A00A37246F318C66CDCFC569 /* Pods-SnapchatKit-OSX-Mantle-Private.xcconfig */;
+			baseConfigurationReference = 33BC1AF5B43B9D9D4E7129B4BC704208 /* Pods-SnapchatKit-OSX-Mantle.xcconfig */;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
@@ -2783,36 +2754,9 @@
 			};
 			name = Debug;
 		};
-		B9A271576786C3A36B11FFFD /* Release */ = {
+		9E523928B3448253495B26B1E68326C8 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DF748A340BF9306E32B97ED3 /* Pods-SnapchatKit_Example-Mantle-Private.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-SnapchatKit_Example-Mantle/Pods-SnapchatKit_Example-Mantle-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit_Example-Mantle/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Example-Mantle/Pods-SnapchatKit_Example-Mantle.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = Mantle;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		C53C0A9BBD2C1288CC4DD6CB /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2D2E53E10F5777B5687B8B84 /* Pods-SnapchatKit_Tests.release.xcconfig */;
+			baseConfigurationReference = 65BDC8FEB0C4DA73E242EB16763477BD /* Pods-SnapchatKit_Tests.debug.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
@@ -2825,6 +2769,68 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Tests/Pods-SnapchatKit_Tests.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = Pods_SnapchatKit_Tests;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		B6B77653AE6B7EF5ABD9DEF9E301354F /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CDEAC9BF0BF4585523A58300F58B3CDD /* Pods-SnapchatKit-OSX.release.xcconfig */;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit-OSX/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit-OSX/Pods-SnapchatKit-OSX.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = Pods_SnapchatKit_OSX;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		F5346DA623ACE706AA12052A410281CB /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 709FA66A2F3014164FA958C13FD036AE /* Pods-SnapchatKit_Tests.release.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit_Tests/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
 				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Tests/Pods-SnapchatKit_Tests.modulemap";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "";
@@ -2839,9 +2845,36 @@
 			};
 			name = Release;
 		};
-		F6FF1FA1613464A565E97F28 /* Debug */ = {
+		F6B21A0364E6FA0FA900975F97E6752B /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B2CC18BCB4D507891F83A273 /* Pods-SnapchatKit_Tests-SnapchatKit-Private.xcconfig */;
+			baseConfigurationReference = 68A1C5A3B897ADB8E2827950CE2912D7 /* Pods-SnapchatKit-OSX-SnapchatKit.xcconfig */;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-SnapchatKit-OSX-SnapchatKit/Pods-SnapchatKit-OSX-SnapchatKit-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit-OSX-SnapchatKit/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit-OSX-SnapchatKit/Pods-SnapchatKit-OSX-SnapchatKit.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = SnapchatKit;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		F869333BC6956F9C2386276A29C883EA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 72F3609C47429493997503C14DD74194 /* Pods-SnapchatKit_Example-SnapchatKit.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
@@ -2850,12 +2883,12 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-SnapchatKit_Tests-SnapchatKit/Pods-SnapchatKit_Tests-SnapchatKit-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit_Tests-SnapchatKit/Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-SnapchatKit_Example-SnapchatKit/Pods-SnapchatKit_Example-SnapchatKit-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit_Example-SnapchatKit/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Tests-SnapchatKit/Pods-SnapchatKit_Tests-SnapchatKit.modulemap";
+				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Example-SnapchatKit/Pods-SnapchatKit_Example-SnapchatKit.modulemap";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_NAME = SnapchatKit;
 				SDKROOT = iphoneos;
@@ -2866,30 +2899,28 @@
 			};
 			name = Debug;
 		};
-		FF36F09F8CEB476B247A2330 /* Debug */ = {
+		FFECA6D0622709252CD61CF518DC205E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B651D104642825FF7BC7098D /* Pods-SnapchatKit-OSX.debug.xcconfig */;
+			baseConfigurationReference = B93970AA91389B580BA81FA9119ABEB4 /* Pods-SnapchatKit_Example-Mantle.xcconfig */;
 			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_VERSION = A;
-				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit-OSX/Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-SnapchatKit_Example-Mantle/Pods-SnapchatKit_Example-Mantle-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Pods-SnapchatKit_Example-Mantle/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
-				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit-OSX/Pods-SnapchatKit-OSX.modulemap";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Pods-SnapchatKit_Example-Mantle/Pods-SnapchatKit_Example-Mantle.modulemap";
 				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = Pods_SnapchatKit_OSX;
-				SDKROOT = macosx;
+				PRODUCT_NAME = Mantle;
+				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -2898,97 +2929,97 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		21768E8FF28EFC7C4A6F38AF /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit-OSX-SnapchatKit" */ = {
+		17B1A745436343209A42AE8E27A1B7F4 /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit-OSX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				5B4EFEF8F877F59478A0A117 /* Debug */,
-				96CCA19679401298913A26E7 /* Release */,
+				2AEEB902C6793BA652251F5DC6EA324E /* Debug */,
+				B6B77653AE6B7EF5ABD9DEF9E301354F /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		24D01F056A1C16DA04FA9DAC /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit_Tests" */ = {
+		2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				6CD95DCC8E3CC8CD7E1518F9 /* Debug */,
-				C53C0A9BBD2C1288CC4DD6CB /* Release */,
+				80C632F58EE202C42BB47E91FB960338 /* Debug */,
+				70D6A3A7860D8F36291F6B722CE9F9F4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		2A94D02702FE9E46AFBFCD56 /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit_Example-Mantle" */ = {
+		3A79B5131730AEB3E75247CDDD89B3DA /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit_Tests-SnapchatKit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				4174B021CEB7D86A5301CB0A /* Debug */,
-				B9A271576786C3A36B11FFFD /* Release */,
+				0A3AE0CE063AB4D8D53086C47B50A574 /* Debug */,
+				8BC6EE817104DAB84386CB1A4BC9E7A0 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		3F46C6AA8A08AA0B1A1F6A41 /* Build configuration list for PBXProject "Pods" */ = {
+		A9776450D6BFEEC49616CC8408403A7F /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit-OSX-Mantle" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				729F80CB83D7035CA985BBE0 /* Debug */,
-				146EB60A01FEB5014E9F85E5 /* Release */,
+				8F968122EA983282306F3399984B5571 /* Debug */,
+				485BAD33A8498D558CAE6C895C23B045 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		4C0BC0CCDD876D425C97D2AD /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit_Example" */ = {
+		BA976E4281AA96A08B4D886E8071851E /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit_Example-Mantle" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				4D9C52DF5FF1F6F61FC5554B /* Debug */,
-				3C48E69B416754A0D93C8B78 /* Release */,
+				FFECA6D0622709252CD61CF518DC205E /* Debug */,
+				837EDE2EF65FBA86E21FC93A612EE69B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		5B7AC3FFAAE97C9D5F91240D /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit-OSX-Mantle" */ = {
+		C21ADECFF486DF21D8DEC124075E5AB8 /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit_Tests-Mantle" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				AE1914EAFDF41DA631EBB31E /* Debug */,
-				4CEAFA43FF6C232D206B4BCE /* Release */,
+				25C05BCB78E0FA751ADC63FF7D310250 /* Debug */,
+				0211CF1FA131D0FC994324626994C3C4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		855D24F3C73AE41FDA40ADE0 /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit-OSX" */ = {
+		C803C9F374D309829EB1D032F4E421EF /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit_Example-SnapchatKit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				FF36F09F8CEB476B247A2330 /* Debug */,
-				0B9B1A5C0B2E0CAE581AFFAF /* Release */,
+				F869333BC6956F9C2386276A29C883EA /* Debug */,
+				5EDBD32C39E404A44393E1D1F29485D0 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		908929BC15B84DFF422DF3F9 /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit_Tests-Mantle" */ = {
+		C941164EFA20A57D383453D58911AF88 /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit-OSX-SnapchatKit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				06440C44ABBA8242EBA08A77 /* Debug */,
-				A11EF6B0853081456886D303 /* Release */,
+				F6B21A0364E6FA0FA900975F97E6752B /* Debug */,
+				859232D9EAAF07288BE565F406937B5C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		C656930BB1F17FF6F9B78306 /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit_Tests-SnapchatKit" */ = {
+		E916328114C6DA8AE450685C4B6F667B /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit_Tests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				F6FF1FA1613464A565E97F28 /* Debug */,
-				8EC9C0827163A18C642FC458 /* Release */,
+				9E523928B3448253495B26B1E68326C8 /* Debug */,
+				F5346DA623ACE706AA12052A410281CB /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		FFE855DEAFDEA1F9A12629CD /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit_Example-SnapchatKit" */ = {
+		F5B8BA0FAB64774C83EE04CA36042ACF /* Build configuration list for PBXNativeTarget "Pods-SnapchatKit_Example" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				1AE4F3DC41496FB11B4B26C7 /* Debug */,
-				A0A0D5EBB7DDDD7616C0E9BA /* Release */,
+				727BB0F812E2A5908B2BCD3187F03C42 /* Debug */,
+				567B8A20A3F29EC90776453F36F1FB1E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = 014DB266874CFCE9C5BCEB5E /* Project object */;
+	rootObject = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 }

--- a/Example/SnapchatKit-OSX/SnapchatKit-OSX.xcodeproj/project.pbxproj
+++ b/Example/SnapchatKit-OSX/SnapchatKit-OSX.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		AD42B37BDA17EA94CF99DED6 /* Pods_SnapchatKit_OSX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1E32E7687F7915C045BD510 /* Pods_SnapchatKit_OSX.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		AD42B37BDA17EA94CF99DED6 /* Pods_SnapchatKit_OSX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1E32E7687F7915C045BD510 /* Pods_SnapchatKit_OSX.framework */; };
 		B4D11BA91B90E3850012116A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = B4D11BA81B90E3850012116A /* main.m */; };
 		B4D11BB11B90E3B60012116A /* TBTimer.m in Sources */ = {isa = PBXBuildFile; fileRef = B4D11BB01B90E3B60012116A /* TBTimer.m */; };
 /* End PBXBuildFile section */
@@ -105,7 +105,6 @@
 				B4D11BA21B90E3850012116A /* Frameworks */,
 				B4D11BA31B90E3850012116A /* CopyFiles */,
 				A0C0DCCB6E4CF45EB5D4467B /* Copy Pods Resources */,
-				B4D11BB31B90FE370012116A /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -177,20 +176,6 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-SnapchatKit-OSX/Pods-SnapchatKit-OSX-resources.sh\"\n";
 			showEnvVarsInLog = 0;
-		};
-		B4D11BB31B90FE370012116A /* Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-SnapchatKit-OSX/Pods-SnapchatKit-OSX-frameworks.sh\"";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Example/SnapchatKit.xcodeproj/project.pbxproj
+++ b/Example/SnapchatKit.xcodeproj/project.pbxproj
@@ -7,9 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		08AB17D438DEF4B786E0474C /* Pods_SnapchatKit_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A36D88C62F269BD5289F85AF /* Pods_SnapchatKit_Example.framework */; };
-		481CFCE04CDEBE40CCA566DD /* Pods_SnapchatKit_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E47288D9F86E267809431017 /* Pods_SnapchatKit_Tests.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
-		58F83C522A8930FC9A05E41F /* Pods_SnapchatKit_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E47288D9F86E267809431017 /* Pods_SnapchatKit_Tests.framework */; };
+		43A340B3E4D125055A02D880 /* Pods_SnapchatKit_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 58CD9903EBCF5FE2F879E8B5 /* Pods_SnapchatKit_Tests.framework */; };
 		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58F195388D20070C39A /* CoreGraphics.framework */; };
 		6003F592195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
@@ -17,17 +15,15 @@
 		6003F59A195388D20070C39A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 6003F599195388D20070C39A /* main.m */; };
 		6003F5A7195388D20070C39A /* SKViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6003F5A6195388D20070C39A /* SKViewController.m */; };
 		6003F5A9195388D20070C39A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6003F5A8195388D20070C39A /* Images.xcassets */; };
-		6003F5B0195388D20070C39A /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F5AF195388D20070C39A /* XCTest.framework */; };
 		6003F5B1195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F5B2195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
 		6003F5BA195388D20070C39A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6003F5B8195388D20070C39A /* InfoPlist.strings */; };
 		6003F5BC195388D20070C39A /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6003F5BB195388D20070C39A /* Tests.m */; };
-		65FA6F8F0B30A1C2746540B8 /* Pods_SnapchatKit_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A36D88C62F269BD5289F85AF /* Pods_SnapchatKit_Example.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
-		8AEB0AD1B633B108B71E7BA6 /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FBAC4DDE7F87C351DBA8578F /* Pods.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		B49E0ED11B6A6F110086F8D0 /* SNTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B49E0ED01B6A6F110086F8D0 /* SNTableViewController.m */; };
 		B49E0ED31B6A6F470086F8D0 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B49E0ED21B6A6F470086F8D0 /* Main.storyboard */; };
 		B49E0ED51B6A6FE80086F8D0 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = B49E0ED41B6A6FE80086F8D0 /* LaunchScreen.xib */; };
 		B4F75D7C1B7A7C3A008E6FF8 /* SKAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = B4F75D7B1B7A7C3A008E6FF8 /* SKAppDelegate.m */; };
+		D6435FFDBBF28130CA56EC70 /* Pods_SnapchatKit_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8D6DF873F27DD61B983F9C4B /* Pods_SnapchatKit_Example.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -41,6 +37,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		58CD9903EBCF5FE2F879E8B5 /* Pods_SnapchatKit_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SnapchatKit_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6003F58A195388D20070C39A /* SnapchatKit_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SnapchatKit_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6003F58D195388D20070C39A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		6003F58F195388D20070C39A /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -54,15 +51,14 @@
 		6003F5A6195388D20070C39A /* SKViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SKViewController.m; sourceTree = "<group>"; };
 		6003F5A8195388D20070C39A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		6003F5AE195388D20070C39A /* SnapchatKit_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SnapchatKit_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		6003F5AF195388D20070C39A /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		6003F5B7195388D20070C39A /* Tests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Tests-Info.plist"; sourceTree = "<group>"; };
 		6003F5B9195388D20070C39A /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		6003F5BB195388D20070C39A /* Tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Tests.m; sourceTree = "<group>"; };
 		606FC2411953D9B200FFA9A0 /* Tests-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Tests-Prefix.pch"; sourceTree = "<group>"; };
 		6414BD2CF8860128C7DA40BF /* Pods-SnapchatKit_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SnapchatKit_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SnapchatKit_Example/Pods-SnapchatKit_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		891C0C84E220E0487354B6C5 /* Pods-SnapchatKit_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SnapchatKit_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SnapchatKit_Tests/Pods-SnapchatKit_Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		8D6DF873F27DD61B983F9C4B /* Pods_SnapchatKit_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SnapchatKit_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B45BD6A6F5EF510EA64C1A4 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
-		A36D88C62F269BD5289F85AF /* Pods_SnapchatKit_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SnapchatKit_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A673B4230E4D3F614D99479C /* Pods-SnapchatKit_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SnapchatKit_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-SnapchatKit_Tests/Pods-SnapchatKit_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		B49E0ECF1B6A6F110086F8D0 /* SNTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SNTableViewController.h; sourceTree = "<group>"; };
 		B49E0ED01B6A6F110086F8D0 /* SNTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SNTableViewController.m; sourceTree = "<group>"; };
@@ -72,9 +68,7 @@
 		B4F75D7B1B7A7C3A008E6FF8 /* SKAppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SKAppDelegate.m; sourceTree = "<group>"; };
 		C50B6337FD849C47AAA86405 /* Pods-SnapchatKit_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SnapchatKit_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-SnapchatKit_Example/Pods-SnapchatKit_Example.release.xcconfig"; sourceTree = "<group>"; };
 		CBB5C915BC5AC56D10244C95 /* SnapchatKit.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = SnapchatKit.podspec; path = ../SnapchatKit.podspec; sourceTree = "<group>"; };
-		E47288D9F86E267809431017 /* Pods_SnapchatKit_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SnapchatKit_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EC5739F6BEA6CC88122E8C68 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
-		FBAC4DDE7F87C351DBA8578F /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -85,9 +79,7 @@
 				6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */,
 				6003F592195388D20070C39A /* UIKit.framework in Frameworks */,
 				6003F58E195388D20070C39A /* Foundation.framework in Frameworks */,
-				08AB17D438DEF4B786E0474C /* Pods_SnapchatKit_Example.framework in Frameworks */,
-				8AEB0AD1B633B108B71E7BA6 /* Pods.framework in Frameworks */,
-				481CFCE04CDEBE40CCA566DD /* Pods_SnapchatKit_Tests.framework in Frameworks */,
+				D6435FFDBBF28130CA56EC70 /* Pods_SnapchatKit_Example.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -95,11 +87,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6003F5B0195388D20070C39A /* XCTest.framework in Frameworks */,
 				6003F5B2195388D20070C39A /* UIKit.framework in Frameworks */,
 				6003F5B1195388D20070C39A /* Foundation.framework in Frameworks */,
-				65FA6F8F0B30A1C2746540B8 /* Pods_SnapchatKit_Example.framework in Frameworks */,
-				58F83C522A8930FC9A05E41F /* Pods_SnapchatKit_Tests.framework in Frameworks */,
+				43A340B3E4D125055A02D880 /* Pods_SnapchatKit_Tests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -144,10 +134,8 @@
 				6003F58D195388D20070C39A /* Foundation.framework */,
 				6003F58F195388D20070C39A /* CoreGraphics.framework */,
 				6003F591195388D20070C39A /* UIKit.framework */,
-				6003F5AF195388D20070C39A /* XCTest.framework */,
-				A36D88C62F269BD5289F85AF /* Pods_SnapchatKit_Example.framework */,
-				E47288D9F86E267809431017 /* Pods_SnapchatKit_Tests.framework */,
-				FBAC4DDE7F87C351DBA8578F /* Pods.framework */,
+				8D6DF873F27DD61B983F9C4B /* Pods_SnapchatKit_Example.framework */,
+				58CD9903EBCF5FE2F879E8B5 /* Pods_SnapchatKit_Tests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -262,7 +250,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = SK;
-				LastUpgradeCheck = 0510;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = ThePantsThief;
 				TargetAttributes = {
 					6003F5AD195388D20070C39A = {
@@ -369,7 +357,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SnapchatKit_Tests/Pods-SnapchatKit_Tests-frameworks.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SnapchatKit_Example/Pods-SnapchatKit_Example-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		D54B0F88C0CDC1A389FC9322 /* Embed Pods Frameworks */ = {
@@ -472,6 +460,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -536,6 +525,7 @@
 				GCC_PREFIX_HEADER = "SnapchatKit/SnapchatKit-Prefix.pch";
 				INFOPLIST_FILE = "SnapchatKit/SnapchatKit-Info.plist";
 				MODULE_NAME = ExampleApp;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -551,6 +541,7 @@
 				GCC_PREFIX_HEADER = "SnapchatKit/SnapchatKit-Prefix.pch";
 				INFOPLIST_FILE = "SnapchatKit/SnapchatKit-Info.plist";
 				MODULE_NAME = ExampleApp;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -573,6 +564,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "Tests/Tests-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SnapchatKit_Example.app/SnapchatKit_Example";
 				WRAPPER_EXTENSION = xctest;
@@ -592,6 +584,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Tests/Tests-Prefix.pch";
 				INFOPLIST_FILE = "Tests/Tests-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SnapchatKit_Example.app/SnapchatKit_Example";
 				WRAPPER_EXTENSION = xctest;

--- a/Example/SnapchatKit.xcodeproj/project.pbxproj
+++ b/Example/SnapchatKit.xcodeproj/project.pbxproj
@@ -7,9 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		08AB17D438DEF4B786E0474C /* Pods_SnapchatKit_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A36D88C62F269BD5289F85AF /* Pods_SnapchatKit_Example.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		08AB17D438DEF4B786E0474C /* Pods_SnapchatKit_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A36D88C62F269BD5289F85AF /* Pods_SnapchatKit_Example.framework */; };
 		481CFCE04CDEBE40CCA566DD /* Pods_SnapchatKit_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E47288D9F86E267809431017 /* Pods_SnapchatKit_Tests.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
-		58F83C522A8930FC9A05E41F /* Pods_SnapchatKit_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E47288D9F86E267809431017 /* Pods_SnapchatKit_Tests.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		58F83C522A8930FC9A05E41F /* Pods_SnapchatKit_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E47288D9F86E267809431017 /* Pods_SnapchatKit_Tests.framework */; };
 		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58F195388D20070C39A /* CoreGraphics.framework */; };
 		6003F592195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };

--- a/Example/SnapchatKit/SKAppDelegate.m
+++ b/Example/SnapchatKit/SKAppDelegate.m
@@ -31,6 +31,13 @@
 }
 
 - (void)trySignIn {
+    static uint16_t authenticationCount = 0;
+    authenticationCount++;
+
+    if (authenticationCount > 3) {
+        return;
+    }
+    
     [[SKClient sharedClient] signInWithUsername:kUsername password:kPassword gmail:kGmail gpass:kGmailPassword completion:^(NSDictionary *dict, NSError *error) {
         if (!error) {
             [self tableViewController].dataSource = [SKClient sharedClient].currentSession.conversations.array;

--- a/Example/SnapchatKit/SNTableViewController.m
+++ b/Example/SnapchatKit/SNTableViewController.m
@@ -35,7 +35,7 @@
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     UITableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:kReuse];
     SKConversation *convo = self.dataSource[indexPath.row];
-    cell.textLabel.text = [NSString stringWithFormat:@"%@ — %lu pending", convo.recipient, convo.pendingRecievedSnaps.count];
+    cell.textLabel.text = [NSString stringWithFormat:@"%@ — %du pending", convo.participants.firstObject, convo.pendingRecievedSnaps.count];
     return cell;
 }
 

--- a/Example/SnapchatKit/SnapchatKit-Info.plist
+++ b/Example/SnapchatKit/SnapchatKit-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Example/Tests/Tests-Info.plist
+++ b/Example/Tests/Tests-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>

--- a/SnapchatKit.podspec
+++ b/SnapchatKit.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
   s.source_files = 'Pod/Classes/*', 'Pod/Classes/**/*', 'Pod/Dependencies/*', 'Pod/Dependencies/**/*'
   # s.dependency 'AFNetworking', '~> 2.5'
   # s.dependency 'SSZipArchive'
-  # s.dependency 'Mantle'
+  s.dependency 'Mantle', '~> 2.0'
   s.library = 'z'
 end

--- a/SnapchatKit.xcworkspace/contents.xcworkspacedata
+++ b/SnapchatKit.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:SnapchatKit.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
This PR adds Mantle to the project via CocoaPods. None of the actual integration work has been started, but it compiles with Mantle included.

I also added a check to the `trySignIn` method to prevent an endlessly loop of authentication attempts – I was using fake credentials to test Mantle, so it would fail every time.
